### PR TITLE
Resaito コマンドが２つ以上の時にshellが終了する挙動の修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ OBJS	= $(addprefix $(SRCSDIR), $(SRCS:.c=.o))
 RE_OBJS	= $(addprefix $(RE_SRCSDIR), $(RE_SRCS:.c=.o))
 
 CC		= cc
-CFLAGS	= #-Wall -Wextra -Werror
+CFLAGS	= -g #-Wall -Wextra -Werror
 RM		= rm -f
 
 LIBFTDIR	= libft/

--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -6,7 +6,7 @@
 /*   By: resaito <resaito@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/18 21:17:45 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/11/01 18:16:23 by fwatanab         ###   ########.fr       */
+/*   Updated: 2023/11/02 16:35:53 by resaito          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -77,6 +77,6 @@ char			*my_strjoin(char const *s1, char const *s2);
 
 //resaito
 char			*search_path(const char *filename);
-void			ft_execution(t_node *node);
+int				ft_execution(t_node *node, bool is_exec_pipe);
 
 #endif

--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -77,6 +77,7 @@ char			*my_strjoin(char const *s1, char const *s2);
 
 //resaito
 char			*search_path(const char *filename);
-int				ft_execution(t_node *node, bool is_exec_pipe);
+int				execution(t_node *node, bool is_exec_pipe);
+void			ft_execution(t_node *node);
 
 #endif

--- a/src/check_token.c
+++ b/src/check_token.c
@@ -1,15 +1,29 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   check_token.c                                      :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: fwatanab <fwatanab@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/10/31 02:25:36 by fwatanab          #+#    #+#             */
+/*   Updated: 2023/10/31 02:27:26 by fwatanab         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
 #include "../inc/minishell.h"
 
 void	check_token(t_token_list *list)
 {
-	t_token_list *tmp;
-	t_token_list *new;
+	t_token_list	*tmp;
+	t_token_list	*new;
 
 	tmp = list;
 	while (tmp->next)
 	{
-		if ((ft_strcmp(tmp->token, "<") == 0 && ft_strcmp(tmp->next->token, "<") == 0)
-			|| (ft_strcmp(tmp->token, ">") == 0 && ft_strcmp(tmp->next->token, ">") == 0))
+		if ((ft_strcmp(tmp->token, "<") == 0
+				&& ft_strcmp(tmp->next->token, "<") == 0)
+			|| (ft_strcmp(tmp->token, ">") == 0
+				&& ft_strcmp(tmp->next->token, ">") == 0))
 		{
 			tmp->token = ft_strjoin(tmp->token, tmp->next->token);
 			new = tmp->next->next;

--- a/src/init.c
+++ b/src/init.c
@@ -6,11 +6,25 @@
 /*   By: fwatanab <fwatanab@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/16 00:15:40 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/10/27 19:31:35 by fwatanab         ###   ########.fr       */
+/*   Updated: 2023/10/31 01:44:59 by fwatanab         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../inc/minishell.h"
+
+t_token_check	*checker_init(void)
+{
+	t_token_check	*check;
+
+	check = (t_token_check *)malloc(sizeof(t_token_check));
+	if (!check)
+		malloc_error();
+	check->start = NULL;
+	check->token = NULL;
+	check->d_quote = false;
+	check->s_quote = false;
+	return (check);
+}
 
 t_node	*node_init(void)
 {

--- a/src/main.c
+++ b/src/main.c
@@ -6,57 +6,42 @@
 /*   By: resaito <resaito@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/18 21:17:52 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/10/30 18:10:47 by resaito          ###   ########.fr       */
+/*   Updated: 2023/10/31 02:51:13 by fwatanab         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../inc/minishell.h"
 
-int	get_args(char *line)
+void	minishell(char *line)
 {
-	char	**input;
-
-	input = ft_split(line, SPACE);
-	if (!input)
-		return (1);
-	return (0);
-}
-
-int	syntax_analysis(char *line)
-{
-	t_token_list	*head;
+	t_token_list	*list;
 	t_node			*node;
 
-	head = NULL;
-	head = tokenize(line, head);
-	if (!head)
-		return (1);
-	check_token(head);
-	// print_list(head);
-	node = parser_start(&head);
-	// print_tree(node, 0);
+	list = tokenize(line);
+	check_token(list);
+//	print_list(list);
+	node = parser_start(&list);
+//	print_tree(node, 0);
 	ft_execution(node);
-	return (0);
+	list_free(&list);
+	node_free(node);
 }
 
 void	bash_loop(void)
 {
 	char	*line;
-	int		flag;
 
-	flag = 0;
-	while (flag == 0)
+	while (1)
 	{
 		line = readline(MINISHELL);
 		if (!line)
-			flag = 1;
+			break ;
 		else if (line[0] == '\0')
 			free(line);
 		else
 		{
 			add_history(line);
-			if (syntax_analysis(line) == 1)
-				flag = 1;
+			minishell(line);
 			free(line);
 		}
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: resaito <resaito@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/18 21:17:52 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/11/02 17:36:02 by resaito          ###   ########.fr       */
+/*   Updated: 2023/11/02 17:58:44 by resaito          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,7 +23,7 @@ void	minishell(char *line)
 	check_token(list);
 //	print_list(list);
 	node = parser_start(&list);
-	print_tree(node, 0);
+	// print_tree(node, 0);
 	ft_execution(node, false);
 	list_free(&tmp);
 	node_free(node);

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: resaito <resaito@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/18 21:17:52 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/11/01 21:40:26 by fwatanab         ###   ########.fr       */
+/*   Updated: 2023/11/02 16:37:00 by resaito          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,8 +23,8 @@ void	minishell(char *line)
 	check_token(list);
 //	print_list(list);
 	node = parser_start(&list);
-//	print_tree(node, 0);
-	ft_execution(node);
+	// print_tree(node, 0);
+	ft_execution(node, false);
 	list_free(&tmp);
 	node_free(node);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -24,7 +24,7 @@ void	minishell(char *line)
 //	print_list(list);
 	node = parser_start(&list);
 	// print_tree(node, 0);
-	ft_execution(node, false);
+	ft_execution(node);
 	list_free(&tmp);
 	node_free(node);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: resaito <resaito@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/18 21:17:52 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/11/02 16:37:00 by resaito          ###   ########.fr       */
+/*   Updated: 2023/11/02 17:36:02 by resaito          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,7 +23,7 @@ void	minishell(char *line)
 	check_token(list);
 //	print_list(list);
 	node = parser_start(&list);
-	// print_tree(node, 0);
+	print_tree(node, 0);
 	ft_execution(node, false);
 	list_free(&tmp);
 	node_free(node);

--- a/src/parser.c
+++ b/src/parser.c
@@ -6,7 +6,7 @@
 /*   By: resaito <resaito@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/25 19:19:00 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/11/02 17:14:42 by fwatanab         ###   ########.fr       */
+/*   Updated: 2023/11/02 18:01:15 by resaito          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -77,11 +77,11 @@ static int	updata_type_value(t_node *node, \
 		}
 		node->name = key->token;
 		key->key_list = *list;
-	printf("11     %s\n", (*list)->token);
+	// printf("11     %s\n", (*list)->token);
 	}
 	else
 	{
-		printf("--------     %s\n", (*list)->token);
+		// printf("--------     %s\n", (*list)->token);
 		node->right = parser(node->right, &key->key_list, key);
 		return (1);
 	}
@@ -119,7 +119,7 @@ t_node	*parser(t_node *node, t_token_list **list, t_parse_check *key)
 	if (!node)
 		return (NULL);
 	key->key_type = false;
-	printf("     %s\n", (*list)->token);
+	// printf("     %s\n", (*list)->token);
 	while (*list)
 	{
 		key->token = pop_token(list);

--- a/src_resaito/exec.c
+++ b/src_resaito/exec.c
@@ -58,7 +58,7 @@ int	execute_command(t_node *node, bool has_pipe)
 }
 
 // #include <stdio.h>
-int	ft_execution(t_node *node, bool is_exec_pipe)
+int	execution(t_node *node, bool is_exec_pipe)
 {	
 	// FILE *fp = fopen("hoge.txt", "a");
 	// fprintf(fp, "type: %d\n", node->type);
@@ -69,8 +69,8 @@ int	ft_execution(t_node *node, bool is_exec_pipe)
 	if (node->type == N_PIPE)
 	{
 		// fprintf(fp, "=========BBB: %s\n", node->name);
-		ft_execution(node->left, true);
-		ft_execution(node->right, false);
+		execution(node->left, true);
+		execution(node->right, false);
 	}
 	// fprintf(fp, "=========CCC: %s\n", node->name);
 	if (node->type == N_COMMAND)
@@ -78,12 +78,22 @@ int	ft_execution(t_node *node, bool is_exec_pipe)
 	return (0);
 }
 
-bool	has_pipe(t_node *node)
+void	ft_execution(t_node *node)
 {
-	if (node->type == N_PIPE)
-		return (true);
-	return (false);
+	int dupin;
+
+	dupin = dup(STDIN_FILENO);
+	execution(node, false);
+	dup2(dupin, STDIN_FILENO);
+	close(dupin);
 }
+
+// bool	has_pipe(t_node *node)
+// {
+// 	if (node->type == N_PIPE)
+// 		return (true);
+// 	return (false);
+// }
 
 // t_node *make_node(enum e_type node_type, char **args)
 // {

--- a/src_resaito/exec.c
+++ b/src_resaito/exec.c
@@ -6,7 +6,7 @@
 /*   By: resaito <resaito@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/30 13:39:58 by resaito           #+#    #+#             */
-/*   Updated: 2023/11/02 17:47:51 by resaito          ###   ########.fr       */
+/*   Updated: 2023/11/02 17:58:34 by resaito          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -57,22 +57,22 @@ int	execute_command(t_node *node, bool has_pipe)
 	}
 }
 
-#include <stdio.h>
+// #include <stdio.h>
 int	ft_execution(t_node *node, bool is_exec_pipe)
 {	
-	FILE *fp = fopen("hoge.txt", "a");
+	// FILE *fp = fopen("hoge.txt", "a");
 	// fprintf(fp, "type: %d\n", node->type);
 	// fprintf(fp, "name: %s\n", node->name);
-	fprintf(fp, "=========AAA: %s\n", node->name);
+	// fprintf(fp, "=========AAA: %s\n", node->name);
 	if (node == NULL)
 		return (0);
 	if (node->type == N_PIPE)
 	{
-		fprintf(fp, "=========BBB: %s\n", node->name);
+		// fprintf(fp, "=========BBB: %s\n", node->name);
 		ft_execution(node->left, true);
 		ft_execution(node->right, false);
 	}
-	fprintf(fp, "=========CCC: %s\n", node->name);
+	// fprintf(fp, "=========CCC: %s\n", node->name);
 	if (node->type == N_COMMAND)
 		execute_command(node, is_exec_pipe);
 	return (0);

--- a/src_resaito/exec.c
+++ b/src_resaito/exec.c
@@ -6,7 +6,7 @@
 /*   By: resaito <resaito@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/30 13:39:58 by resaito           #+#    #+#             */
-/*   Updated: 2023/11/02 16:34:12 by resaito          ###   ########.fr       */
+/*   Updated: 2023/11/02 17:47:51 by resaito          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -57,15 +57,22 @@ int	execute_command(t_node *node, bool has_pipe)
 	}
 }
 
+#include <stdio.h>
 int	ft_execution(t_node *node, bool is_exec_pipe)
-{
+{	
+	FILE *fp = fopen("hoge.txt", "a");
+	// fprintf(fp, "type: %d\n", node->type);
+	// fprintf(fp, "name: %s\n", node->name);
+	fprintf(fp, "=========AAA: %s\n", node->name);
 	if (node == NULL)
 		return (0);
 	if (node->type == N_PIPE)
 	{
+		fprintf(fp, "=========BBB: %s\n", node->name);
 		ft_execution(node->left, true);
 		ft_execution(node->right, false);
 	}
+	fprintf(fp, "=========CCC: %s\n", node->name);
 	if (node->type == N_COMMAND)
 		execute_command(node, is_exec_pipe);
 	return (0);

--- a/src_resaito/exec.c
+++ b/src_resaito/exec.c
@@ -6,7 +6,7 @@
 /*   By: resaito <resaito@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/30 13:39:58 by resaito           #+#    #+#             */
-/*   Updated: 2023/10/31 14:55:40 by resaito          ###   ########.fr       */
+/*   Updated: 2023/10/31 16:11:36 by resaito          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,7 +14,8 @@
 
 bool	has_pipe(t_node *node);
 
-void	execute_command(char *cmd_name, char **args, int input_fd, int output_fd)
+void	execute_command(char *cmd_name, char **args, int input_fd,
+		int output_fd)
 {
 	if (fork() == 0)
 	{


### PR DESCRIPTION
コマンドが２つ以上の時にshellが終了する挙動を修正しました。

// 原因
dup2でpipefd[0]→STDIN_FILENOをした後にcloseするとSTDIN_FILENOもcloseされてreadlineが読み込めない→line = NULLになるので終了するようです。

// 修正内容
dup2を使用する前にdup()を使ってSTDIN_FILENOを複製(= dupin)し、dupinをcloseをしても元のSTDIN_FILENOをcloseしないように修正しました。