### PR TITLE
Resaito

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,9 @@ SRCS = main.c free.c tokenize.c check_token.c utils.c parser.c redir_parser.c pa
 
 RE_SRCSDIR	= src_resaito/
 
-RE_SRCS = exec.c search_path.c
+RE_SRCS = exec.c \
+			search_path.c \
+			redirect_dup.c
 
 OBJS	= $(addprefix $(SRCSDIR), $(SRCS:.c=.o))
 

--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -6,7 +6,7 @@
 /*   By: resaito <resaito@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/18 21:17:45 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/11/14 13:39:13 by resaito          ###   ########.fr       */
+/*   Updated: 2023/11/15 14:40:19 by resaito          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -91,6 +91,6 @@ char			*search_path(const char *filename);
 int				execution(t_node *node, bool is_exec_pipe);
 void			ft_execution(t_node *node);
 int				redir_dup(t_node *node, int *pipefd);
-int				indirect_exec(t_node *node, int *pipefd);
+int				indirect_exec(t_node *node, int dupout);
 
 #endif

--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -6,7 +6,7 @@
 /*   By: resaito <resaito@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/18 21:17:45 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/11/11 15:51:00 by fwatanab         ###   ########.fr       */
+/*   Updated: 2023/11/13 15:31:44 by resaito          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -90,5 +90,6 @@ char			*my_strjoin(char const *s1, char const *s2);
 char			*search_path(const char *filename);
 int				execution(t_node *node, bool is_exec_pipe);
 void			ft_execution(t_node *node);
+int				redir_dup(t_node *node, int *pipefd);
 
 #endif

--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -6,7 +6,7 @@
 /*   By: resaito <resaito@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/18 21:17:45 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/11/13 15:31:44 by resaito          ###   ########.fr       */
+/*   Updated: 2023/11/14 13:39:13 by resaito          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -91,5 +91,6 @@ char			*search_path(const char *filename);
 int				execution(t_node *node, bool is_exec_pipe);
 void			ft_execution(t_node *node);
 int				redir_dup(t_node *node, int *pipefd);
+int				indirect_exec(t_node *node, int *pipefd);
 
 #endif

--- a/src_resaito/exec.c
+++ b/src_resaito/exec.c
@@ -18,6 +18,7 @@ int	execute_command(t_node *node, bool has_pipe)
 	int		pipefd[2];
 	pid_t	pid;
 	int		status;
+	char	*line;
 
 	if (has_pipe)
 	{
@@ -62,6 +63,7 @@ int	execute_command(t_node *node, bool has_pipe)
 int	execution(t_node *node, bool is_exec_pipe)
 {	
 	int	dupout;
+	char *line;
 
 	if (node == NONE)
 		return (0);
@@ -72,7 +74,9 @@ int	execution(t_node *node, bool is_exec_pipe)
 		execution(node->right, false);
 	}
 	if (node->type == N_COMMAND)
+	{
 		execute_command(node, is_exec_pipe);
+	}
 	return (0);
 }
 
@@ -98,7 +102,9 @@ void	ft_execution(t_node *node)
 
 	dupin = dup(STDIN_FILENO);
 	execution(node, false);
+	system("leaks -q minishell");
 	wait_all(node);
+	// system("leaks -q minishell");
 	dup2(dupin, STDIN_FILENO);
 	close(dupin);
 }
@@ -147,16 +153,17 @@ void	ft_execution(t_node *node)
 // 	char *file[] = {"hoge.txt", NULL};
 // 	char *file2[] = {"fuga.txt", NULL};
 // 	char *file3[] = {"piyo.txt", NULL};
+// 	char *eof[] = {"hoge", NULL};
 
-//     ast = make_node(N_PIPE, ls);
-//     ast->left = make_node(N_COMMAND, cat);
-//     ast->right = make_node(N_PIPE, ls);
-//     ast->right = make_node(N_COMMAND, grep);
-//     ast->right->right = make_node(N_COMMAND, wc);
+//     // ast = make_node(N_PIPE, ls);
+//     ast = make_node(N_COMMAND, cat);
+//     // ast->right = make_node(N_PIPE, ls);
+//     // ast->right = make_node(N_COMMAND, grep);
+//     // ast->right->right = make_node(N_COMMAND, wc);
 
-// 	redir = make_redir(N_REDIR_IN, file);
-// 	redir->next = make_redir(N_REDIR_IN, file3);
-// 	redir->next->next = make_redir(N_REDIR_OUT, file2);
+// 	redir = make_redir(N_REDIR_HERE, eof);
+// 	// redir->next = make_redir(N_REDIR_IN, file3);
+// 	// redir->next->next = make_redir(N_REDIR_OUT, file2);
 // 	ast->redir = redir;
 // 	// redir->next = redir2;
 //     ft_execution(ast);

--- a/src_resaito/exec.c
+++ b/src_resaito/exec.c
@@ -6,7 +6,7 @@
 /*   By: resaito <resaito@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/30 13:39:58 by resaito           #+#    #+#             */
-/*   Updated: 2023/11/13 16:29:03 by resaito          ###   ########.fr       */
+/*   Updated: 2023/11/14 15:11:44 by resaito          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -48,6 +48,7 @@ int	execute_command(t_node *node, bool has_pipe)
 	}
 	else
 	{
+		indirect_exec(node, pipefd);
 		if (has_pipe)
 		{
 			close(pipefd[1]);
@@ -133,25 +134,28 @@ void	ft_execution(t_node *node)
 // {
 //     t_node *ast;
 // 	t_redir *redir;
+// 	t_redir *redir2;
 //     // char *args[] = {"/usr/bin/wc", "-l", NULL};
 //     // char *args2[] = {"/bin/cat", NULL};
 //     // char *args3[] = {"/usr/bin/grep", "hoge", NULL};
 //     char *ls[] = {"/bin/ls", NULL};
 //     char *cat[] = {"/bin/cat", NULL};
 //     char *wc[] = {"/usr/bin/wc", "-l", NULL};
-//     char *grep[] = {"/usr/bin/grep", "a.out", NULL};
+//     char *grep[] = {"/usr/bin/grep", "hoge", NULL};
 // 	char *file[] = {"hoge.txt", NULL};
 // 	char *file2[] = {"fuga.txt", NULL};
+// 	char *file3[] = {"piyo.txt", NULL};
 
 //     ast = make_node(N_PIPE, ls);
-//     ast->left = make_node(N_COMMAND, ls);
+//     ast->left = make_node(N_COMMAND, cat);
 //     ast->right = make_node(N_PIPE, ls);
 //     ast->right->left = make_node(N_COMMAND, grep);
 //     ast->right->right = make_node(N_COMMAND, wc);
 
-// 	redir = make_redir(N_REDIR_OUT, file);
-// 	redir->next = make_redir(N_REDIR_APPEND, file2);
-// 	ast->right->right->redir = redir;
+// 	redir = make_redir(N_REDIR_IN, file);
+// 	// redir2 = make_redir(N_REDIR_OUT, file3);
+// 	ast->left->redir = redir;
+// 	// ast->right->right->redir = redir2;
 //     ft_execution(ast);
 //     // command_exec(args2, true);
 //     // command_exec(args3, false);

--- a/src_resaito/exec.c
+++ b/src_resaito/exec.c
@@ -144,7 +144,7 @@ void	ft_execution(t_node *node)
 // 	char *file2[] = {"fuga.txt", NULL};
 
 //     ast = make_node(N_PIPE, ls);
-//     ast = make_node(N_COMMAND, ls);
+//     ast->left = make_node(N_COMMAND, ls);
 //     ast->right = make_node(N_PIPE, ls);
 //     ast->right->left = make_node(N_COMMAND, grep);
 //     ast->right->right = make_node(N_COMMAND, wc);

--- a/src_resaito/exec.c
+++ b/src_resaito/exec.c
@@ -46,7 +46,6 @@ int	execute_command(t_node *node, bool has_pipe)
 	}
 	else
 	{
-		waitpid(pid, &status, 0);
 		if (has_pipe)
 		{
 			close(pipefd[1]);
@@ -60,22 +59,32 @@ int	execute_command(t_node *node, bool has_pipe)
 // #include <stdio.h>
 int	execution(t_node *node, bool is_exec_pipe)
 {	
-	// FILE *fp = fopen("hoge.txt", "a");
-	// fprintf(fp, "type: %d\n", node->type);
-	// fprintf(fp, "name: %s\n", node->name);
-	// fprintf(fp, "=========AAA: %s\n", node->name);
 	if (node == NULL)
 		return (0);
 	if (node->type == N_PIPE)
 	{
-		// fprintf(fp, "=========BBB: %s\n", node->name);
 		execution(node->left, true);
 		execution(node->right, false);
 	}
-	// fprintf(fp, "=========CCC: %s\n", node->name);
 	if (node->type == N_COMMAND)
 		execute_command(node, is_exec_pipe);
 	return (0);
+}
+
+void wait_all(t_node *node)
+{
+	int status;
+
+	if (node == NULL)
+		return ;
+	if (node->type == N_PIPE)
+	{
+		wait_all(node->left);
+		wait_all(node->right);
+	}
+	if (node->type == N_COMMAND)
+		wait(&status);
+	return ;
 }
 
 void	ft_execution(t_node *node)
@@ -84,6 +93,7 @@ void	ft_execution(t_node *node)
 
 	dupin = dup(STDIN_FILENO);
 	execution(node, false);
+	wait_all(node);
 	dup2(dupin, STDIN_FILENO);
 	close(dupin);
 }

--- a/src_resaito/exec.c
+++ b/src_resaito/exec.c
@@ -6,7 +6,7 @@
 /*   By: resaito <resaito@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/30 13:39:58 by resaito           #+#    #+#             */
-/*   Updated: 2023/11/13 14:33:58 by resaito          ###   ########.fr       */
+/*   Updated: 2023/11/13 15:31:06 by resaito          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -41,13 +41,7 @@ int	execute_command(t_node *node, bool has_pipe)
 			dup2(pipefd[1], STDOUT_FILENO);
 			close(pipefd[1]);
 		}
-		if (node->redir != NULL && node->redir->type == N_REDIR_OUT)
-		{
-			close(pipefd[0]);
-			pipefd[1] = open(node->redir->file[0], O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
-			dup2(pipefd[1], STDOUT_FILENO);
-			close(pipefd[1]);
-		}
+		redir_dup(node, pipefd);
 		execve(node->name, node->args, NULL);
 		perror(node->name);
 		return (-1);
@@ -124,6 +118,17 @@ void	ft_execution(t_node *node)
 //     return node;
 // }
 
+// t_redir *make_redir(char **file)
+// {
+// 	t_redir *redir;
+
+// 	redir = malloc(sizeof(t_redir) * 1);
+// 	redir->file = file;
+// 	redir->type = N_REDIR_OUT;
+// 	redir->next = NULL;
+// 	return redir;
+// }
+
 // int main()
 // {
 //     t_node *ast;
@@ -136,6 +141,7 @@ void	ft_execution(t_node *node)
 //     char *wc[] = {"/usr/bin/wc", "-l", NULL};
 //     char *grep[] = {"/usr/bin/grep", "a.out", NULL};
 // 	char *file[] = {"hoge.txt", NULL};
+// 	char *file2[] = {"hoge2.txt", NULL};
 
 //     ast = make_node(N_PIPE, ls);
 //     ast->left = make_node(N_COMMAND, ls);
@@ -143,10 +149,8 @@ void	ft_execution(t_node *node)
 //     ast->right->left = make_node(N_COMMAND, grep);
 //     ast->right->right = make_node(N_COMMAND, wc);
 
-// 	redir = malloc(sizeof(t_redir) * 1);
-// 	redir->file = file;
-// 	redir->type = N_REDIR_OUT;
-// 	redir->next = NULL;
+// 	redir = make_redir(file);
+// 	redir->next = make_redir(file2);
 // 	ast->right->right->redir = redir;
 //     ft_execution(ast);
 //     // command_exec(args2, true);

--- a/src_resaito/exec.c
+++ b/src_resaito/exec.c
@@ -6,7 +6,7 @@
 /*   By: resaito <resaito@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/30 13:39:58 by resaito           #+#    #+#             */
-/*   Updated: 2023/11/13 15:31:06 by resaito          ###   ########.fr       */
+/*   Updated: 2023/11/13 16:29:03 by resaito          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -118,13 +118,13 @@ void	ft_execution(t_node *node)
 //     return node;
 // }
 
-// t_redir *make_redir(char **file)
+// t_redir *make_redir(enum e_type node_type, char **file)
 // {
 // 	t_redir *redir;
 
 // 	redir = malloc(sizeof(t_redir) * 1);
 // 	redir->file = file;
-// 	redir->type = N_REDIR_OUT;
+// 	redir->type = node_type;
 // 	redir->next = NULL;
 // 	return redir;
 // }
@@ -141,16 +141,16 @@ void	ft_execution(t_node *node)
 //     char *wc[] = {"/usr/bin/wc", "-l", NULL};
 //     char *grep[] = {"/usr/bin/grep", "a.out", NULL};
 // 	char *file[] = {"hoge.txt", NULL};
-// 	char *file2[] = {"hoge2.txt", NULL};
+// 	char *file2[] = {"fuga.txt", NULL};
 
 //     ast = make_node(N_PIPE, ls);
-//     ast->left = make_node(N_COMMAND, ls);
+//     ast = make_node(N_COMMAND, ls);
 //     ast->right = make_node(N_PIPE, ls);
 //     ast->right->left = make_node(N_COMMAND, grep);
 //     ast->right->right = make_node(N_COMMAND, wc);
 
-// 	redir = make_redir(file);
-// 	redir->next = make_redir(file2);
+// 	redir = make_redir(N_REDIR_OUT, file);
+// 	redir->next = make_redir(N_REDIR_APPEND, file2);
 // 	ast->right->right->redir = redir;
 //     ft_execution(ast);
 //     // command_exec(args2, true);

--- a/src_resaito/exec.c
+++ b/src_resaito/exec.c
@@ -6,7 +6,7 @@
 /*   By: resaito <resaito@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/30 13:39:58 by resaito           #+#    #+#             */
-/*   Updated: 2023/11/14 15:11:44 by resaito          ###   ########.fr       */
+/*   Updated: 2023/11/15 14:41:54 by resaito          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -48,7 +48,6 @@ int	execute_command(t_node *node, bool has_pipe)
 	}
 	else
 	{
-		indirect_exec(node, pipefd);
 		if (has_pipe)
 		{
 			close(pipefd[1]);
@@ -62,8 +61,11 @@ int	execute_command(t_node *node, bool has_pipe)
 // #include <stdio.h>
 int	execution(t_node *node, bool is_exec_pipe)
 {	
+	int	dupout;
+
 	if (node == NONE)
 		return (0);
+	indirect_exec(node, dupout);
 	if (node->type == N_PIPE)
 	{
 		execution(node->left, true);
@@ -147,14 +149,14 @@ void	ft_execution(t_node *node)
 // 	char *file3[] = {"piyo.txt", NULL};
 
 //     ast = make_node(N_PIPE, ls);
-//     ast->left = make_node(N_COMMAND, cat);
+//     ast->right = make_node(N_COMMAND, cat);
 //     ast->right = make_node(N_PIPE, ls);
 //     ast->right->left = make_node(N_COMMAND, grep);
 //     ast->right->right = make_node(N_COMMAND, wc);
 
 // 	redir = make_redir(N_REDIR_IN, file);
 // 	// redir2 = make_redir(N_REDIR_OUT, file3);
-// 	ast->left->redir = redir;
+// 	ast->right->redir = redir;
 // 	// ast->right->right->redir = redir2;
 //     ft_execution(ast);
 //     // command_exec(args2, true);

--- a/src_resaito/exec.c
+++ b/src_resaito/exec.c
@@ -6,11 +6,12 @@
 /*   By: resaito <resaito@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/30 13:39:58 by resaito           #+#    #+#             */
-/*   Updated: 2023/11/02 17:58:34 by resaito          ###   ########.fr       */
+/*   Updated: 2023/11/13 14:33:58 by resaito          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../inc/minishell.h"
+#include <fcntl.h>
 
 int	execute_command(t_node *node, bool has_pipe)
 {
@@ -40,6 +41,13 @@ int	execute_command(t_node *node, bool has_pipe)
 			dup2(pipefd[1], STDOUT_FILENO);
 			close(pipefd[1]);
 		}
+		if (node->redir != NULL && node->redir->type == N_REDIR_OUT)
+		{
+			close(pipefd[0]);
+			pipefd[1] = open(node->redir->file[0], O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
+			dup2(pipefd[1], STDOUT_FILENO);
+			close(pipefd[1]);
+		}
 		execve(node->name, node->args, NULL);
 		perror(node->name);
 		return (-1);
@@ -59,7 +67,7 @@ int	execute_command(t_node *node, bool has_pipe)
 // #include <stdio.h>
 int	execution(t_node *node, bool is_exec_pipe)
 {	
-	if (node == NULL)
+	if (node == NONE)
 		return (0);
 	if (node->type == N_PIPE)
 	{
@@ -75,7 +83,7 @@ void wait_all(t_node *node)
 {
 	int status;
 
-	if (node == NULL)
+	if (node == NONE)
 		return ;
 	if (node->type == N_PIPE)
 	{
@@ -119,20 +127,28 @@ void	ft_execution(t_node *node)
 // int main()
 // {
 //     t_node *ast;
+// 	t_redir *redir;
 //     // char *args[] = {"/usr/bin/wc", "-l", NULL};
 //     // char *args2[] = {"/bin/cat", NULL};
 //     // char *args3[] = {"/usr/bin/grep", "hoge", NULL};
 //     char *ls[] = {"/bin/ls", NULL};
 //     char *cat[] = {"/bin/cat", NULL};
 //     char *wc[] = {"/usr/bin/wc", "-l", NULL};
-//     char *grep[] = {"/usr/bin/grep", "hoge", NULL};
+//     char *grep[] = {"/usr/bin/grep", "a.out", NULL};
+// 	char *file[] = {"hoge.txt", NULL};
 
 //     ast = make_node(N_PIPE, ls);
 //     ast->left = make_node(N_COMMAND, ls);
 //     ast->right = make_node(N_PIPE, ls);
 //     ast->right->left = make_node(N_COMMAND, grep);
 //     ast->right->right = make_node(N_COMMAND, wc);
-//     ft_execution(ast, false);
+
+// 	redir = malloc(sizeof(t_redir) * 1);
+// 	redir->file = file;
+// 	redir->type = N_REDIR_OUT;
+// 	redir->next = NULL;
+// 	ast->right->right->redir = redir;
+//     ft_execution(ast);
 //     // command_exec(args2, true);
 //     // command_exec(args3, false);
 //     // wait(NULL);

--- a/src_resaito/exec.c
+++ b/src_resaito/exec.c
@@ -6,7 +6,7 @@
 /*   By: resaito <resaito@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/30 13:39:58 by resaito           #+#    #+#             */
-/*   Updated: 2023/11/15 14:41:54 by resaito          ###   ########.fr       */
+/*   Updated: 2023/11/16 17:05:29 by resaito          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -149,15 +149,16 @@ void	ft_execution(t_node *node)
 // 	char *file3[] = {"piyo.txt", NULL};
 
 //     ast = make_node(N_PIPE, ls);
-//     ast->right = make_node(N_COMMAND, cat);
+//     ast->left = make_node(N_COMMAND, cat);
 //     ast->right = make_node(N_PIPE, ls);
-//     ast->right->left = make_node(N_COMMAND, grep);
+//     ast->right = make_node(N_COMMAND, grep);
 //     ast->right->right = make_node(N_COMMAND, wc);
 
 // 	redir = make_redir(N_REDIR_IN, file);
-// 	// redir2 = make_redir(N_REDIR_OUT, file3);
-// 	ast->right->redir = redir;
-// 	// ast->right->right->redir = redir2;
+// 	redir->next = make_redir(N_REDIR_IN, file3);
+// 	redir->next->next = make_redir(N_REDIR_OUT, file2);
+// 	ast->redir = redir;
+// 	// redir->next = redir2;
 //     ft_execution(ast);
 //     // command_exec(args2, true);
 //     // command_exec(args3, false);

--- a/src_resaito/redirect_dup.c
+++ b/src_resaito/redirect_dup.c
@@ -15,24 +15,23 @@
 
 int	redir_dup(t_node *node, int *pipefd)
 {
-	if (node->redir != NULL && (node->redir->type == N_REDIR_OUT
+	if (!(node->redir != NULL && (node->redir->type == N_REDIR_OUT
+			|| node->redir->type == N_REDIR_APPEND)))
+		return (0);
+	close(pipefd[0]);
+	while (node->redir != NULL && (node->redir->type == N_REDIR_OUT
 			|| node->redir->type == N_REDIR_APPEND))
 	{
-		close(pipefd[0]);
-		while (node->redir != NULL && (node->redir->type == N_REDIR_OUT
-				|| node->redir->type == N_REDIR_APPEND))
-		{
-			if (node->redir->type == N_REDIR_OUT)
-				pipefd[1] = open(node->redir->file[0],
-						O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
-			else
-				pipefd[1] = open(node->redir->file[0],
-						O_WRONLY | O_CREAT | O_APPEND, S_IRUSR | S_IWUSR);
-			node->redir = node->redir->next;
-		}
-		dup2(pipefd[1], STDOUT_FILENO);
-		close(pipefd[1]);
+		if (node->redir->type == N_REDIR_OUT)
+			pipefd[1] = open(node->redir->file[0],
+					O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
+		else
+			pipefd[1] = open(node->redir->file[0],
+					O_WRONLY | O_CREAT | O_APPEND, S_IRUSR | S_IWUSR);
+		node->redir = node->redir->next;
 	}
+	dup2(pipefd[1], STDOUT_FILENO);
+	close(pipefd[1]);
 	return (0);
 }
 

--- a/src_resaito/redirect_dup.c
+++ b/src_resaito/redirect_dup.c
@@ -6,7 +6,7 @@
 /*   By: resaito <resaito@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/09 14:05:49 by resaito           #+#    #+#             */
-/*   Updated: 2023/11/13 16:27:56 by resaito          ###   ########.fr       */
+/*   Updated: 2023/11/13 16:42:53 by resaito          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,7 +19,8 @@ int	redir_dup(t_node *node, int *pipefd)
 			|| node->redir->type == N_REDIR_APPEND))
 	{
 		close(pipefd[0]);
-		while (node->redir != NULL)
+		while (node->redir != NULL && (node->redir->type == N_REDIR_OUT
+				|| node->redir->type == N_REDIR_APPEND))
 		{
 			if (node->redir->type == N_REDIR_OUT)
 				pipefd[1] = open(node->redir->file[0],

--- a/src_resaito/redirect_dup.c
+++ b/src_resaito/redirect_dup.c
@@ -1,41 +1,34 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   redirect_exec.c                                    :+:      :+:    :+:   */
+/*   redirect_dup.c                                     :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: resaito <resaito@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/09 14:05:49 by resaito           #+#    #+#             */
-/*   Updated: 2023/11/09 15:06:47 by resaito          ###   ########.fr       */
+/*   Updated: 2023/11/13 15:28:49 by resaito          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../inc/minishell.h"
 #include <fcntl.h>
-#include <unistd.h>
 
 #define BUF_SIZE 512
 
-int	redirect_exec(t_node *node)
+int	redir_dup(t_node *node, int *pipefd)
 {
-	int		stdout_fd;
-	char	*file_name;
-
-	// 変数定義
-	// 変数初期化
-	stdout_fd = 0;
-	// ファイルのオープン
-	stdout_fd = open(file_name, O_WRONLY | O_CREAT, S_IRUSR | S_IWUSR);
-	if (stdout_fd == -1) // ファイルオープン失敗
+	if (node->redir != NULL && node->redir->type == N_REDIR_OUT)
 	{
-		printf("ファイルオープンエラー\n");
-		return (1);
+		close(pipefd[0]);
+		while (node->redir != NULL)
+		{
+			pipefd[1] = open(node->redir->file[0], O_WRONLY | O_CREAT | O_TRUNC,
+					S_IRUSR | S_IWUSR);
+			node->redir = node->redir->next;
+		}
+		dup2(pipefd[1], STDOUT_FILENO);
+		close(pipefd[1]);
 	}
-	dup2(stdout_fd, STDOUT_FILENO);
-	close(stdout_fd);
-	execve(node->name, node->args, NULL);
-	dup2(stdout_fd, STDOUT_FILENO);
-	close(stdout_fd);
 	return (0);
 }
 

--- a/src_resaito/redirect_dup.c
+++ b/src_resaito/redirect_dup.c
@@ -6,7 +6,7 @@
 /*   By: resaito <resaito@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/09 14:05:49 by resaito           #+#    #+#             */
-/*   Updated: 2023/11/16 17:36:01 by resaito          ###   ########.fr       */
+/*   Updated: 2023/11/16 17:49:53 by resaito          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -70,69 +70,66 @@ int	heredoc_exec(char *delimiter)
 			free(line);
 			break ;
 		}
-		// if (line != NULL)
-		// 	write(pipefd[1], line, ft_strlen(line));
-		// write(pipefd[1], "\n", 1);
-		printf("%s\n", line);
+		ft_putendl_fd(line, pipefd[1]);
 		free(line);
 	}
 	close(pipefd[1]);
 	return (pipefd[0]);
 }
 
-t_node *make_node(enum e_type node_type, char **args)
-{
-    t_node *node;
+// t_node *make_node(enum e_type node_type, char **args)
+// {
+//     t_node *node;
 
-    node = calloc(sizeof(t_node), 1);
-    node->type = node_type;
-    node->name = args[0];
-    node->args = args;
-    return node;
-}
+//     node = calloc(sizeof(t_node), 1);
+//     node->type = node_type;
+//     node->name = args[0];
+//     node->args = args;
+//     return node;
+// }
 
-t_redir *make_redir(enum e_type node_type, char **file)
-{
-	t_redir *redir;
+// t_redir *make_redir(enum e_type node_type, char **file)
+// {
+// 	t_redir *redir;
 
-	redir = malloc(sizeof(t_redir) * 1);
-	redir->file = file;
-	redir->type = node_type;
-	redir->next = NULL;
-	return redir;
-}
+// 	redir = malloc(sizeof(t_redir) * 1);
+// 	redir->file = file;
+// 	redir->type = node_type;
+// 	redir->next = NULL;
+// 	return redir;
+// }
 
-int main()
-{
-    t_node *ast;
-	t_redir *redir;
-	t_redir *redir2;
-    // char *args[] = {"/usr/bin/wc", "-l", NULL};
-    // char *args2[] = {"/bin/cat", NULL};
-    // char *args3[] = {"/usr/bin/grep", "hoge", NULL};
-    char *ls[] = {"/bin/ls", NULL};
-    char *cat[] = {"/bin/cat", NULL};
-    char *wc[] = {"/usr/bin/wc", "-l", NULL};
-    char *grep[] = {"/usr/bin/grep", "hoge", NULL};
-	char *file[] = {"hoge.txt", NULL};
-	char *file2[] = {"fuga.txt", NULL};
-	char *file3[] = {"piyo.txt", NULL};
-	char *eof[] = {"hoge", NULL};
+// int main()
+// {
+//     t_node *ast;
+// 	t_redir *redir;
+// 	t_redir *redir2;
+//     // char *args[] = {"/usr/bin/wc", "-l", NULL};
+//     // char *args2[] = {"/bin/cat", NULL};
+//     // char *args3[] = {"/usr/bin/grep", "hoge", NULL};
+//     char *ls[] = {"/bin/ls", NULL};
+//     char *cat[] = {"/bin/cat", NULL};
+//     char *wc[] = {"/usr/bin/wc", "-l", NULL};
+//     char *grep[] = {"/usr/bin/grep", "hoge", NULL};
+// 	char *file[] = {"hoge.txt", NULL};
+// 	char *file2[] = {"fuga.txt", NULL};
+// 	char *file3[] = {"piyo.txt", NULL};
+// 	char *eof[] = {"hoge", NULL};
 
-    // ast = make_node(N_PIPE, ls);
-    ast = make_node(N_COMMAND, cat);
-    // ast->right = make_node(N_PIPE, ls);
-    // ast->right = make_node(N_COMMAND, grep);
-    // ast->right->right = make_node(N_COMMAND, wc);
+//     // ast = make_node(N_PIPE, ls);
+//     ast = make_node(N_COMMAND, cat);
+//     // ast->right = make_node(N_PIPE, ls);
+//     // ast->right = make_node(N_COMMAND, grep);
+//     // ast->right->right = make_node(N_COMMAND, wc);
 
-	redir = make_redir(N_REDIR_HERE, eof);
-	// redir->next = make_redir(N_REDIR_IN, file3);
-	// redir->next->next = make_redir(N_REDIR_OUT, file2);
-	ast->redir = redir;
-	// redir->next = redir2;
-    heredoc_exec(ast->redir->file[0]);
-    // command_exec(args2, true);
-    // command_exec(args3, false);
-    // wait(NULL);
-    // wait(NULL);
-}
+// 	redir = make_redir(N_REDIR_HERE, eof);
+// 	// redir->next = make_redir(N_REDIR_IN, file3);
+// 	// redir->next->next = make_redir(N_REDIR_OUT, file2);
+// 	ast->redir = redir;
+// 	// redir->next = redir2;
+//     heredoc_exec(ast->redir->file[0]);
+//     // command_exec(args2, true);
+//     // command_exec(args3, false);
+//     // wait(NULL);
+//     // wait(NULL);
+// }

--- a/src_resaito/redirect_dup.c
+++ b/src_resaito/redirect_dup.c
@@ -6,7 +6,7 @@
 /*   By: resaito <resaito@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/09 14:05:49 by resaito           #+#    #+#             */
-/*   Updated: 2023/11/13 16:42:53 by resaito          ###   ########.fr       */
+/*   Updated: 2023/11/14 15:11:47 by resaito          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,7 +16,7 @@
 int	redir_dup(t_node *node, int *pipefd)
 {
 	if (!(node->redir != NULL && (node->redir->type == N_REDIR_OUT
-			|| node->redir->type == N_REDIR_APPEND)))
+				|| node->redir->type == N_REDIR_APPEND)))
 		return (0);
 	close(pipefd[0]);
 	while (node->redir != NULL && (node->redir->type == N_REDIR_OUT
@@ -35,17 +35,18 @@ int	redir_dup(t_node *node, int *pipefd)
 	return (0);
 }
 
-int	indirect_exec(t_node *node)
+int	indirect_exec(t_node *node, int *pipefd)
 {
-	int		stdin_fd;
-	char	*file;
-
-	stdin_fd = 0;
-	stdin_fd = open(file, O_RDONLY);
-	dup2(stdin_fd, STDIN_FILENO);
-	close(stdin_fd);
-	execve(node->name, node->args, NULL);
-	dup2(stdin_fd, STDIN_FILENO);
-	close(stdin_fd);
+	if (!(node->redir != NULL && node->redir->type == N_REDIR_IN))
+		return (0);
+	close(pipefd[1]);
+	while (node->redir != NULL && (node->redir->type == N_REDIR_IN))
+	{
+		if (node->redir->type == N_REDIR_IN)
+			pipefd[0] = open(node->redir->file[0], O_RDONLY);
+		node->redir = node->redir->next;
+	}
+	dup2(pipefd[0], STDIN_FILENO);
+	close(pipefd[0]);
 	return (0);
 }

--- a/src_resaito/redirect_dup.c
+++ b/src_resaito/redirect_dup.c
@@ -6,7 +6,7 @@
 /*   By: resaito <resaito@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/09 14:05:49 by resaito           #+#    #+#             */
-/*   Updated: 2023/11/15 14:39:14 by resaito          ###   ########.fr       */
+/*   Updated: 2023/11/16 17:36:01 by resaito          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -48,4 +48,91 @@ int	indirect_exec(t_node *node, int dupout)
 	dup2(dupout, STDIN_FILENO);
 	close(dupout);
 	return (0);
+}
+
+int	heredoc_exec(char *delimiter)
+{
+	char	*line;
+	int		pipefd[2];
+
+	if (pipe(pipefd) < 0)
+	{
+		perror("pipe");
+		exit(-1);
+	}
+	while (1)
+	{
+		line = readline("> ");
+		if (line == NULL)
+			break ;
+		if (ft_strncmp(line, delimiter, ft_strlen(delimiter)) == 0)
+		{
+			free(line);
+			break ;
+		}
+		// if (line != NULL)
+		// 	write(pipefd[1], line, ft_strlen(line));
+		// write(pipefd[1], "\n", 1);
+		printf("%s\n", line);
+		free(line);
+	}
+	close(pipefd[1]);
+	return (pipefd[0]);
+}
+
+t_node *make_node(enum e_type node_type, char **args)
+{
+    t_node *node;
+
+    node = calloc(sizeof(t_node), 1);
+    node->type = node_type;
+    node->name = args[0];
+    node->args = args;
+    return node;
+}
+
+t_redir *make_redir(enum e_type node_type, char **file)
+{
+	t_redir *redir;
+
+	redir = malloc(sizeof(t_redir) * 1);
+	redir->file = file;
+	redir->type = node_type;
+	redir->next = NULL;
+	return redir;
+}
+
+int main()
+{
+    t_node *ast;
+	t_redir *redir;
+	t_redir *redir2;
+    // char *args[] = {"/usr/bin/wc", "-l", NULL};
+    // char *args2[] = {"/bin/cat", NULL};
+    // char *args3[] = {"/usr/bin/grep", "hoge", NULL};
+    char *ls[] = {"/bin/ls", NULL};
+    char *cat[] = {"/bin/cat", NULL};
+    char *wc[] = {"/usr/bin/wc", "-l", NULL};
+    char *grep[] = {"/usr/bin/grep", "hoge", NULL};
+	char *file[] = {"hoge.txt", NULL};
+	char *file2[] = {"fuga.txt", NULL};
+	char *file3[] = {"piyo.txt", NULL};
+	char *eof[] = {"hoge", NULL};
+
+    // ast = make_node(N_PIPE, ls);
+    ast = make_node(N_COMMAND, cat);
+    // ast->right = make_node(N_PIPE, ls);
+    // ast->right = make_node(N_COMMAND, grep);
+    // ast->right->right = make_node(N_COMMAND, wc);
+
+	redir = make_redir(N_REDIR_HERE, eof);
+	// redir->next = make_redir(N_REDIR_IN, file3);
+	// redir->next->next = make_redir(N_REDIR_OUT, file2);
+	ast->redir = redir;
+	// redir->next = redir2;
+    heredoc_exec(ast->redir->file[0]);
+    // command_exec(args2, true);
+    // command_exec(args3, false);
+    // wait(NULL);
+    // wait(NULL);
 }

--- a/src_resaito/redirect_dup.c
+++ b/src_resaito/redirect_dup.c
@@ -6,7 +6,7 @@
 /*   By: resaito <resaito@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/09 14:05:49 by resaito           #+#    #+#             */
-/*   Updated: 2023/11/14 15:11:47 by resaito          ###   ########.fr       */
+/*   Updated: 2023/11/15 14:39:14 by resaito          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,18 +35,17 @@ int	redir_dup(t_node *node, int *pipefd)
 	return (0);
 }
 
-int	indirect_exec(t_node *node, int *pipefd)
+int	indirect_exec(t_node *node, int dupout)
 {
 	if (!(node->redir != NULL && node->redir->type == N_REDIR_IN))
 		return (0);
-	close(pipefd[1]);
 	while (node->redir != NULL && (node->redir->type == N_REDIR_IN))
 	{
 		if (node->redir->type == N_REDIR_IN)
-			pipefd[0] = open(node->redir->file[0], O_RDONLY);
+			dupout = open(node->redir->file[0], O_RDONLY);
 		node->redir = node->redir->next;
 	}
-	dup2(pipefd[0], STDIN_FILENO);
-	close(pipefd[0]);
+	dup2(dupout, STDIN_FILENO);
+	close(dupout);
 	return (0);
 }

--- a/src_resaito/redirect_dup.c
+++ b/src_resaito/redirect_dup.c
@@ -6,24 +6,27 @@
 /*   By: resaito <resaito@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/09 14:05:49 by resaito           #+#    #+#             */
-/*   Updated: 2023/11/13 15:28:49 by resaito          ###   ########.fr       */
+/*   Updated: 2023/11/13 16:27:56 by resaito          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../inc/minishell.h"
 #include <fcntl.h>
 
-#define BUF_SIZE 512
-
 int	redir_dup(t_node *node, int *pipefd)
 {
-	if (node->redir != NULL && node->redir->type == N_REDIR_OUT)
+	if (node->redir != NULL && (node->redir->type == N_REDIR_OUT
+			|| node->redir->type == N_REDIR_APPEND))
 	{
 		close(pipefd[0]);
 		while (node->redir != NULL)
 		{
-			pipefd[1] = open(node->redir->file[0], O_WRONLY | O_CREAT | O_TRUNC,
-					S_IRUSR | S_IWUSR);
+			if (node->redir->type == N_REDIR_OUT)
+				pipefd[1] = open(node->redir->file[0],
+						O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
+			else
+				pipefd[1] = open(node->redir->file[0],
+						O_WRONLY | O_CREAT | O_APPEND, S_IRUSR | S_IWUSR);
 			node->redir = node->redir->next;
 		}
 		dup2(pipefd[1], STDOUT_FILENO);

--- a/src_resaito/redirect_dup.c
+++ b/src_resaito/redirect_dup.c
@@ -37,13 +37,16 @@ int	redir_dup(t_node *node, int *pipefd)
 
 int	indirect_exec(t_node *node, int dupout)
 {
-	if (!(node->redir != NULL && node->redir->type == N_REDIR_IN))
+	t_redir *redir;
+
+	redir = node->redir;
+	if (!(redir != NULL && redir->type == N_REDIR_IN))
 		return (0);
-	while (node->redir != NULL && (node->redir->type == N_REDIR_IN))
+	while (redir != NULL && (redir->type == N_REDIR_IN))
 	{
-		if (node->redir->type == N_REDIR_IN)
-			dupout = open(node->redir->file[0], O_RDONLY);
-		node->redir = node->redir->next;
+		if (redir->type == N_REDIR_IN)
+			dupout = open(redir->file[0], O_RDONLY);
+		redir = redir->next;
 	}
 	dup2(dupout, STDIN_FILENO);
 	close(dupout);

--- a/src_resaito/redirect_hoge.c
+++ b/src_resaito/redirect_hoge.c
@@ -1,0 +1,55 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   redirect_exec.c                                    :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: resaito <resaito@student.42.fr>            +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/11/09 14:05:49 by resaito           #+#    #+#             */
+/*   Updated: 2023/11/09 15:06:47 by resaito          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../inc/minishell.h"
+#include <fcntl.h>
+#include <unistd.h>
+
+#define BUF_SIZE 512
+
+int	redirect_exec(t_node *node)
+{
+	int		stdout_fd;
+	char	*file_name;
+
+	// 変数定義
+	// 変数初期化
+	stdout_fd = 0;
+	// ファイルのオープン
+	stdout_fd = open(file_name, O_WRONLY | O_CREAT, S_IRUSR | S_IWUSR);
+	if (stdout_fd == -1) // ファイルオープン失敗
+	{
+		printf("ファイルオープンエラー\n");
+		return (1);
+	}
+	dup2(stdout_fd, STDOUT_FILENO);
+	close(stdout_fd);
+	execve(node->name, node->args, NULL);
+	dup2(stdout_fd, STDOUT_FILENO);
+	close(stdout_fd);
+	return (0);
+}
+
+int	indirect_exec(t_node *node)
+{
+	int		stdin_fd;
+	char	*file;
+
+	stdin_fd = 0;
+	stdin_fd = open(file, O_RDONLY);
+	dup2(stdin_fd, STDIN_FILENO);
+	close(stdin_fd);
+	execve(node->name, node->args, NULL);
+	dup2(stdin_fd, STDIN_FILENO);
+	close(stdin_fd);
+	return (0);
+}


### PR DESCRIPTION
## issue
close #10 

## やったこと

indirectを実行した時にリークするのを解決

## 詳細
元のriderが上書きされてfreeできない状態になっていた
```
node->rider = node->rider->next;
```

新しくt_riderを宣言し、nodeを書き換えないようにした
```
t_rider *rider;
~
rider = rider->next;
```