### PR TITLE
$? の実装と${}の挙動修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ NAME	= minishell
 
 SRCSDIR	= src/
 
-SRCS = main.c free.c tokenize.c check_token.c parser.c redir_parser.c parser_utils.c lexer_parser_init.c expansion.c exp_init.c expand_parameter.c signal.c print.c
+SRCS = main.c free.c tokenize.c check_token.c parser.c redir_parser.c parser_utils.c lexer_parser_init.c expansion.c exp_init.c expand_parameter.c expand_utils.c signal.c print.c
 
 RE_SRCSDIR	= src_resaito/
 

--- a/inc/expansion.h
+++ b/inc/expansion.h
@@ -3,21 +3,17 @@
 /*                                                        :::      ::::::::   */
 /*   expansion.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: resaito <resaito@student.42.fr>            +#+  +:+       +#+        */
+/*   By: fwatanab <fwatanab@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/12 03:53:40 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/11/29 17:35:15 by resaito          ###   ########.fr       */
+/*   Updated: 2023/12/06 22:10:07 by fwatanab         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef EXPANSION_H
 # define EXPANSION_H
 
-# include "../libft/inc/libft.h"
-# include "../libft/inc/libft_utils.h"
-# include <stdio.h>
-# include <stdbool.h>
-# include <string.h>
+# include "minishell.h"
 
 typedef struct s_parm
 {
@@ -31,7 +27,9 @@ typedef struct s_parm
 //init
 t_parm	*parameter_init(char *token);
 
-char	*check_parameter(t_parm *parm, char *token);
-char	*expand_parameter(char *token);
+char	*check_parameter(t_parm *parm, char *token, t_envval *envval);
+int		check_question(t_parm *parm, char *token, t_envval *envval);
+char	*update_string_with_status(t_parm *parm, char *status_str);
+void check_brackets_balance(size_t *brackets, char **token, char *env_name, t_parm *parm);
 
 #endif

--- a/src/expand_parameter.c
+++ b/src/expand_parameter.c
@@ -6,7 +6,7 @@
 /*   By: fwatanab <fwatanab@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/18 23:43:04 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/11/25 16:39:39 by fwatanab         ###   ########.fr       */
+/*   Updated: 2023/12/06 22:09:29 by fwatanab         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,6 +47,8 @@ static char	*parse_parameter(char *token, char *env_name, t_parm *parm)
 			brackets++;
 		else if ((brackets < 2 && 0 < brackets) && token[i] == '}')
 			brackets++;
+		else if (token[i] != '_' && ft_isalnum(token[i]) != 1)
+			return (NULL);
 		else if (token[i] == '{' || token[i] == '}')
 			break ;
 		else
@@ -54,7 +56,7 @@ static char	*parse_parameter(char *token, char *env_name, t_parm *parm)
 		i++;
 	}
 	env_name[j] = '\0';
-	parm->end = &token[i];
+	check_brackets_balance(&brackets, &token, env_name, parm);
 	return (env_name);
 }
 
@@ -109,17 +111,20 @@ static char	*expand_env_variable(t_parm *parm)
 	return (parm->str);
 }
 
-char	*check_parameter(t_parm *parm, char *token)
+char	*check_parameter(t_parm *parm, char *token, t_envval *envval)
 {
 	while (*parm->tmp)
 	{
 		if (*parm->tmp == '$' && *(parm->tmp + 1) != ' '
 			&& *(parm->tmp + 1) != '\0' && *(parm->tmp + 1) != '"')
 		{
-			parm->str = expand_env_variable(parm);
+			if (check_question(parm, token, envval) == 1)
+			{
+				parm->str = expand_env_variable(parm);
+				parm->tmp = parm->end;
+			}
 			if (!parm->str)
 				return (NULL);
-			parm->tmp = parm->end;
 		}
 		else
 		{

--- a/src/expand_utils.c
+++ b/src/expand_utils.c
@@ -1,0 +1,76 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   expand_utils.c                                     :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: fwatanab <fwatanab@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/12/06 21:05:33 by fwatanab          #+#    #+#             */
+/*   Updated: 2023/12/06 22:14:10 by fwatanab         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../inc/expansion.h"
+
+char	*update_string_with_status(t_parm *parm, char *status_str)
+{
+	char	*new;
+	size_t	new_len;
+
+	new_len = ft_strlen(parm->str) + ft_strlen(status_str);
+	new = ft_realloc(parm->str, new_len + 1);
+	if (!new)
+	{
+		free(parm->str);
+		return (NULL);
+	}
+	ft_strcat(new, status_str);
+	parm->str = new;
+	return (parm->str);
+}
+
+int	check_question(t_parm *parm, char *token, t_envval *envval)
+{
+	char	*tmp;
+
+	if (*(parm->tmp + 1) == '{' && *(parm->tmp + 2) == '?'
+		&& *(parm->tmp + 3) == '}')
+	{
+		tmp = ft_itoa(envval->status);
+		parm->str = update_string_with_status(parm, tmp);
+		free(tmp);
+		if (!parm->str)
+			return (-1);
+		parm->tmp += 4;
+		return (0);
+	}
+	else if (*(parm->tmp + 1) == '?')
+	{
+		tmp = ft_itoa(envval->status);
+		parm->str = update_string_with_status(parm, tmp);
+		free(tmp);
+		if (!parm->str)
+			return (-1);
+		parm->tmp += 2;
+		return (0);
+	}
+	return (1);
+}
+
+void	check_brackets_balance(size_t *brackets, \
+		char **token, char *env_name, t_parm *parm)
+{
+	size_t	i;
+
+	i = 1;
+	if (*brackets % 2 == 1)
+	{
+		env_name[0] = '\0';
+		while ((*token)[i] && (*token)[i] != '}')
+			i++;
+		if ((*token)[i] == '}')
+			i++;
+	}
+	*brackets = 0;
+	parm->end = &(*token)[i];
+}

--- a/src/expansion.c
+++ b/src/expansion.c
@@ -6,14 +6,13 @@
 /*   By: fwatanab <fwatanab@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/11 17:52:58 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/11/25 16:34:59 by fwatanab         ###   ########.fr       */
+/*   Updated: 2023/12/05 22:14:51 by fwatanab         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "../inc/minishell.h"
 #include "../inc/expansion.h"
 
-char	*expand_parameter(char *token)
+char	*expand_parameter(char *token, t_envval *envval)
 {
 	t_parm	*parm;
 	char	*new_token;
@@ -23,7 +22,7 @@ char	*expand_parameter(char *token)
 	parm = parameter_init(token);
 	if (!parm)
 		return (token);
-	parm->str = check_parameter(parm, token);
+	parm->str = check_parameter(parm, token, envval);
 	if (!parm->str)
 		return (token);
 	new_token = ft_strdup(parm->str);
@@ -86,7 +85,7 @@ char	*check_command(char *str)
 	return (str);
 }
 
-void	expansion(char **array)
+void	expansion(char **array, t_envval *envval)
 {
 	char	*new_array;
 	size_t	i;
@@ -96,13 +95,13 @@ void	expansion(char **array)
 	while (array[i])
 	{
 		array[i] = check_command(array[i]);
-		array[i] = expand_parameter(array[i]);
+		array[i] = expand_parameter(array[i], envval);
 		array[i] = delete_quote(array[i]);
 		i++;
 	}
 }
 
-void	check_exp(t_node *node)
+void	check_exp(t_node *node, t_envval *envval)
 {
 	size_t	i;
 
@@ -110,9 +109,9 @@ void	check_exp(t_node *node)
 	if (!node)
 		return ;
 	if (node->args)
-		expansion(node->args);
+		expansion(node->args, envval);
 	if (node->left)
-		check_exp(node->left);
+		check_exp(node->left, envval);
 	if (node->right)
-		check_exp(node->right);
+		check_exp(node->right, envval);
 }


### PR DESCRIPTION
**$?、${?}の実装**
```
minishell $ echo $?
0
minishell $ echo ${?}
0

```
**${}の中に空白や環境変数として認識されない記号が入ってきたときに空を返すように統一しようと思います**

```
bash $ echo ${HOME;}
bash: ${HOME;}: bad substitution
bash $ echo ${HOME#}
/Users/sukakaedefutoshi

minishell $ echo ${HOME;}

minishell $ echo ${HOME#}


```