### PR TITLE
builtinコマンドの実装

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ RE_SRCS = exec.c \
 			ft_xmalloc.c \
 			ft_perror.c \
 			ft_pipe.c \
-			execution_by_process.c
+			execution_by_process.c \
+			print_error.c
 
 OBJS	= $(addprefix $(SRCSDIR), $(SRCS:.c=.o))
 

--- a/Makefile
+++ b/Makefile
@@ -17,14 +17,22 @@ RE_SRCS = exec.c \
 			ft_perror.c \
 			ft_pipe.c \
 			execution_by_process.c \
-			print_error.c
+			print_error.c \
+			builtin/builtin.c \
+			builtin/cd.c \
+			builtin/echo.c \
+			builtin/export.c \
+			builtin/ft_env.c \
+			builtin/pwd.c \
+			builtin/unset.c \
+			is_single_command.c
 
 OBJS	= $(addprefix $(SRCSDIR), $(SRCS:.c=.o))
 
 RE_OBJS	= $(addprefix $(RE_SRCSDIR), $(RE_SRCS:.c=.o))
 
 CC		= cc
-CFLAGS	= -g -I$(READLINEDIR)/include #-Wall -Wextra -Werror
+CFLAGS	= -g -I$(READLINEDIR)/include #-fsanitize=address #-Wall -Wextra -Werror
 RM		= rm -f
 READLINEDIR    := $(shell brew --prefix readline)
 

--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -89,7 +89,7 @@ t_node			*parser(t_node *node, t_token_list **list, t_parse_check *key);
 t_redir			*redir_parse(t_node *node, t_redir *redir, t_token_list **list, char *token);
 
 //expansion
-void			check_exp(t_node *node);
+void			check_exp(t_node *node, t_envval *envval);
 
 //signal
 void			signal_handler(int sig);
@@ -110,15 +110,15 @@ char			*search_path(const char *filename);
 // exec
 int				execution(t_node *node, bool is_exec_pipe, t_envval *envval);
 void			ft_execution(t_node *node, t_envval *envval);
-void			child_process(t_node *node, bool has_pipe, t_envval *envval,
+int				child_process(t_node *node, bool has_pipe, t_envval *envval,
 					int pipefd[2]);
 void			parent_process(bool has_pipe, int pipefd[2]);
 
 // redir
 int				redir_dup(t_node *node);
 int				indirect_exec(t_node *node);
-int				heredoc_exec(t_redir *redir);
-int				input_redir(t_node *node);
+int				heredoc_exec(t_redir *redir, t_envval *envval);
+int				input_redir(t_node *node, t_envval *envval);
 bool			is_type_heredoc(t_redir *redir);
 bool			is_type_indirect(t_redir *redir);
 void			dup_2_stdin(t_node *node);
@@ -137,5 +137,6 @@ t_envval		*make_envval(t_env *env);
 void			*ft_xmalloc(size_t size);
 void			ft_perror(char *str);
 int				ft_pipe(int pipefd[2]);
+int				print_error(char *command, char *error, int status);
 
 #endif

--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -6,7 +6,7 @@
 /*   By: resaito <resaito@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/18 21:17:45 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/12/04 15:27:59 by resaito          ###   ########.fr       */
+/*   Updated: 2023/12/08 13:38:23 by resaito          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -131,6 +131,7 @@ char			**make_env_strs(t_env *env);
 size_t			ft_list_size(t_env *env);
 void			envs_free(t_env *env);
 void			envs_str_free(t_env *env, char **str);
+void			env_free(t_env *env);
 t_envval		*make_envval(t_env *env);
 
 // utils

--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -134,10 +134,21 @@ void			envs_str_free(t_env *env, char **str);
 void			env_free(t_env *env);
 t_envval		*make_envval(t_env *env);
 
+// builtin
+bool			is_builtin(t_node *node);
+void			exec_builtin(t_node *node, t_envval *envval);
+int				cd(t_node *node, t_envval *envval);
+int				echo(t_node *node);
+int				export(t_node *node, t_envval *envval);
+int				ft_env(t_envval *envval);
+int				pwd(t_envval *envval);
+int				unset(t_node *node, t_envval *envval);
+
 // utils
 void			*ft_xmalloc(size_t size);
 void			ft_perror(char *str);
 int				ft_pipe(int pipefd[2]);
 int				print_error(char *command, char *error, int status);
+bool			is_single_command(t_node *node);
 
 #endif

--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -108,7 +108,7 @@ void			malloc_error(void);
 char			*search_path(const char *filename);
 
 // exec
-int				execution(t_node *node, bool is_exec_pipe, t_envval *envval);
+void			execution(t_node *node, bool is_exec_pipe, t_envval *envval);
 void			ft_execution(t_node *node, t_envval *envval);
 int				child_process(t_node *node, bool has_pipe, t_envval *envval,
 					int pipefd[2]);
@@ -121,7 +121,7 @@ int				heredoc_exec(t_redir *redir, t_envval *envval);
 int				input_redir(t_node *node, t_envval *envval);
 bool			is_type_heredoc(t_redir *redir);
 bool			is_type_indirect(t_redir *redir);
-void			dup_2_stdin(t_node *node);
+int				dup_2_stdin(t_node *node);
 
 // env
 t_env			*new_envs(char **envp);

--- a/src/main.c
+++ b/src/main.c
@@ -24,7 +24,7 @@ void	minishell(char *line, t_envval *envval)
 	check_token(list);
 //	print_list(list);
 	node = parser_start(&list);
-	check_exp(node);
+	check_exp(node, envval);
 	ft_execution(node, envval);
 //	print_node(node);
 	list_free(&tmp);

--- a/src/parser.c
+++ b/src/parser.c
@@ -106,10 +106,10 @@ t_node	*parser_start(t_token_list **list)
 	t_node			*node;
 	t_parse_check	*key;
 
-	node = (t_node *)malloc(sizeof(t_node));
+	node = (t_node *)ft_calloc(sizeof(t_node), 1);
 	if (!node)
 		return (NULL);
-	key = (t_parse_check *)malloc(sizeof(t_parse_check));
+	key = (t_parse_check *)ft_calloc(sizeof(t_parse_check), 1);
 	if (!key)
 		return (NULL);
 	node = parser(node, list, key);

--- a/src_resaito/biltin.c
+++ b/src_resaito/biltin.c
@@ -1,39 +1,51 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   biltin.c                                           :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: resaito <resaito@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/12/08 13:32:35 by resaito           #+#    #+#             */
+/*   Updated: 2023/12/08 13:33:05 by resaito          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
 #include "../inc/minishell.h"
 
-bool    is_biltin(t_node *node)
+bool	is_biltin(t_node *node)
 {
-    if (ft_strcmp(node->args[0], "echo") == 0)
-        return (true);
-    else if (ft_strcmp(node->args[0], "cd") == 0)
-        return (true);
-    else if (ft_strcmp(node->args[0], "pwd") == 0)
-        return (true);
-    else if (ft_strcmp(node->args[0], "export") == 0)
-        return (true);
-    else if (ft_strcmp(node->args[0], "unset") == 0)
-        return (true);
-    else if (ft_strcmp(node->args[0], "env") == 0)
-        return (true);
-    else if (ft_strcmp(node->args[0], "exit") == 0)
-        return (true);
-    else
-        return (false);
+	if (ft_strcmp(node->args[0], "echo") == 0)
+		return (true);
+	else if (ft_strcmp(node->args[0], "cd") == 0)
+		return (true);
+	else if (ft_strcmp(node->args[0], "pwd") == 0)
+		return (true);
+	else if (ft_strcmp(node->args[0], "export") == 0)
+		return (true);
+	else if (ft_strcmp(node->args[0], "unset") == 0)
+		return (true);
+	else if (ft_strcmp(node->args[0], "env") == 0)
+		return (true);
+	else if (ft_strcmp(node->args[0], "exit") == 0)
+		return (true);
+	else
+		return (false);
 }
 
-void    exec_biltin(t_node *node, t_envval *envval)
+void	exec_biltin(t_node *node, t_envval *envval)
 {
-    if (ft_strcmp(node->args[0], "echo") == 0)
-        envval->status = echo(node);
-    else if (ft_strcmp(node->args[0], "cd") == 0)
-        envval->status = cd(node, envval);
-    else if (ft_strcmp(node->args[0], "pwd") == 0)
-        envval->status = pwd(envval);
-    else if (ft_strcmp(node->args[0], "export") == 0)
-        envval->status = export(node, envval);
-    else if (ft_strcmp(node->args[0], "unset") == 0)
-        envval->status = unset(node, envval);
-    else if (ft_strcmp(node->args[0], "env") == 0)
-        envval->status = env(envval);
-    else if (ft_strcmp(node->args[0], "exit") == 0)
-        envval->status = exit(node, envval);
+	if (ft_strcmp(node->args[0], "echo") == 0)
+		envval->status = echo(node);
+	else if (ft_strcmp(node->args[0], "cd") == 0)
+		envval->status = cd(node, envval);
+	else if (ft_strcmp(node->args[0], "pwd") == 0)
+		envval->status = pwd(envval);
+	else if (ft_strcmp(node->args[0], "export") == 0)
+		envval->status = export(node, envval);
+	else if (ft_strcmp(node->args[0], "unset") == 0)
+		envval->status = unset(node, envval);
+	else if (ft_strcmp(node->args[0], "env") == 0)
+		envval->status = env(envval);
+	else if (ft_strcmp(node->args[0], "exit") == 0)
+		envval->status = ft_exit(node, envval);
 }

--- a/src_resaito/builtin/builtin.c
+++ b/src_resaito/builtin/builtin.c
@@ -26,8 +26,8 @@ bool	is_builtin(t_node *node)
 		return (true);
 	else if (ft_strcmp(node->args[0], "env") == 0)
 		return (true);
-	else if (ft_strcmp(node->args[0], "exit") == 0)
-		return (true);
+	// else if (ft_strcmp(node->args[0], "exit") == 0)
+	// 	return (true);
 	else
 		return (false);
 }
@@ -45,7 +45,7 @@ void	exec_builtin(t_node *node, t_envval *envval)
 	else if (ft_strcmp(node->args[0], "unset") == 0)
 		envval->status = unset(node, envval);
 	else if (ft_strcmp(node->args[0], "env") == 0)
-		envval->status = env(envval);
-	else if (ft_strcmp(node->args[0], "exit") == 0)
-		envval->status = ft_exit(node, envval);
+		envval->status = ft_env(envval);
+	// else if (ft_strcmp(node->args[0], "exit") == 0)
+	// 	envval->status = ft_exit(node, envval);
 }

--- a/src_resaito/builtin/builtin.c
+++ b/src_resaito/builtin/builtin.c
@@ -1,18 +1,18 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   biltin.c                                           :+:      :+:    :+:   */
+/*   builtin.c                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: resaito <resaito@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/08 13:32:35 by resaito           #+#    #+#             */
-/*   Updated: 2023/12/08 13:33:05 by resaito          ###   ########.fr       */
+/*   Updated: 2023/12/08 16:08:29 by resaito          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "../inc/minishell.h"
+#include "../../inc/minishell.h"
 
-bool	is_biltin(t_node *node)
+bool	is_builtin(t_node *node)
 {
 	if (ft_strcmp(node->args[0], "echo") == 0)
 		return (true);
@@ -32,7 +32,7 @@ bool	is_biltin(t_node *node)
 		return (false);
 }
 
-void	exec_biltin(t_node *node, t_envval *envval)
+void	exec_builtin(t_node *node, t_envval *envval)
 {
 	if (ft_strcmp(node->args[0], "echo") == 0)
 		envval->status = echo(node);

--- a/src_resaito/builtin/cd.c
+++ b/src_resaito/builtin/cd.c
@@ -6,11 +6,11 @@
 /*   By: resaito <resaito@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/04 16:14:59 by resaito           #+#    #+#             */
-/*   Updated: 2023/12/04 17:54:06 by resaito          ###   ########.fr       */
+/*   Updated: 2023/12/08 16:08:38 by resaito          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "../inc/minishell.h"
+#include "../../inc/minishell.h"
 
 #define PATHNAME_SIZE 512
 

--- a/src_resaito/builtin/echo.c
+++ b/src_resaito/builtin/echo.c
@@ -1,32 +1,38 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   ft_env.c                                           :+:      :+:    :+:   */
+/*   echo.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: resaito <resaito@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2023/12/08 15:24:50 by resaito           #+#    #+#             */
-/*   Updated: 2023/12/08 15:55:22 by resaito          ###   ########.fr       */
+/*   Created: 2023/12/08 16:07:03 by resaito           #+#    #+#             */
+/*   Updated: 2023/12/08 16:52:48 by resaito          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "../inc/minishell.h"
+#include "../../inc/minishell.h"
 
-int	ft_env(t_envval *envval)
+int	echo(t_node *node)
 {
-	char	**str;
+	bool	option;
 	size_t	len;
 
-	if (!(envval->env))
-		return (1);
-	str = make_env_strs(envval->env);
-	len = 0;
-	while (str[len])
+	option = false;
+	len = 1;
+	if (node->args[1] && ft_strcmp(node->args[1], "-n") == 0)
 	{
-		printf("%s\n", str[len]);
+		option = true;
+		len = 2;
+	}
+	while (node->args[len])
+	{
+		ft_putstr_fd(node->args[len], STDOUT_FILENO);
+		if (node->args[len + 1])
+			write(STDOUT_FILENO, " ", 1);
 		len++;
 	}
-    str_array_free(str);
+	if (!option)
+		write(STDOUT_FILENO, "\n", 1);
 	return (0);
 }
 
@@ -43,19 +49,14 @@ int	ft_env(t_envval *envval)
 
 // int	main(int ac, char **av, char **envp)
 // {
-// 	// t_node		*node;
-// 	t_envval	*envval;
-// 	// char		*env_arg[] = {"env", NULL};
+// 	t_node		*node;
+// 	char		*echo_arg[] = {"echo", "aaaa", "aaaa", "aaaa", "aaaa",
+// 				NULL};
 
-// 	// node = make_node(N_COMMAND, env_arg);
-// 	envval = make_envval(new_envs(envp)); //make_envval.c make_env.c
-// 	ft_env(envval);
-// 	// free(node);
-// 	envs_free(envval->env); //env_free.c ../src/free.c
-// 	free(envval);
+// 	node = make_node(N_COMMAND, echo_arg);
+// 	// envval = make_envval(new_envs(envp)); //make_envval.c make_env.c
+// 	echo(node);
+// 	free(node);
+// 	// envs_free(envval->env); //env_free.c ../src/free.c
+// 	// free(envval);
 // } // ../libft/libft.a
-
-// __attribute__((destructor))
-// static void destructor() {
-// 	system("leaks -q a.out");
-// }

--- a/src_resaito/builtin/export.c
+++ b/src_resaito/builtin/export.c
@@ -1,48 +1,59 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   unset.c                                            :+:      :+:    :+:   */
+/*   export.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: resaito <resaito@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2023/12/08 13:27:05 by resaito           #+#    #+#             */
-/*   Updated: 2023/12/08 13:51:17 by resaito          ###   ########.fr       */
+/*   Created: 2023/12/08 13:28:22 by resaito           #+#    #+#             */
+/*   Updated: 2023/12/08 16:56:10 by resaito          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "../inc/minishell.h"
+#include "../../inc/minishell.h"
 
-int	unset(t_node *node, t_envval *envval)
+static size_t	len_2_equal(char *str);
+
+int	export(t_node *node, t_envval *envval)
 {
 	size_t	size;
 	t_env	*tmp;
-	t_env	*tmp_back;
+	size_t	equal_len;
 
 	size = 1;
 	while (node->args[size] != NULL)
 	{
-		tmp = envval->env;
-		tmp_back = tmp;
-		while (ft_strcmp(node->args[size], tmp->key) != 0 && tmp->next)
-		{
-			tmp_back = tmp;
-			tmp = tmp->next;
-		}
-		if (tmp->next)
-		{
-			if (tmp == envval->env)
-				envval->env = tmp->next;
-			else if (tmp->next)
-				tmp_back->next = tmp->next;
-		}
-		else if (ft_strcmp(node->args[size], tmp->key) == 0)
-			tmp_back->next = NULL;
-		else
+		equal_len = len_2_equal(node->args[size]);
+		if (equal_len == 0)
 			return (1);
-		env_free(tmp);
+		tmp = envval->env;
+		while (tmp->next && ft_strncmp(tmp->key, node->args[size],
+				equal_len) != 0)
+			tmp = tmp->next;
+		if (ft_strncmp(tmp->key, node->args[size], equal_len) == 0)
+		{
+			free(tmp->value);
+			tmp->value = ft_strdup(node->args[size] + (equal_len + 1));
+		}
+		else
+			envadd_back(&(envval->env), new_env(node->args[size]));
 		size++;
 	}
 	return (0);
+}
+
+static size_t	len_2_equal(char *str)
+{
+	size_t	len;
+
+	len = 0;
+	if (str == NULL)
+		return (0);
+	while (str[len] != '\0' && str[len] != '=')
+		len++;
+	if (str[len] != '=')
+		return (0);
+	return (len);
 }
 
 // t_node	*make_node(enum e_type node_type, char **args)
@@ -59,27 +70,25 @@ int	unset(t_node *node, t_envval *envval)
 // int	main(int ac, char **av, char **envp)
 // {
 // 	t_node	*node;
-// 	// t_env	*env;
-//     t_envval *envval;
+// 	t_env	*env;
 //     char    **array;
 //     int     size = 0;
-// 	char	*unset_arg[] = {"export", "$PATH", NULL};
+// 	char	*export_arg[] = {"export", "PATH", NULL};
 
-// 	node = make_node(N_COMMAND, unset_arg);
-// 	envval = make_envval(new_envs(envp)); //make_envval.c make_env.c
-// 	printf("%d\n",unset(node, envval));
-//     array = make_env_strs(envval->env); //make_env.c
-//     envs_free(envval->env); // env_free.c
-//     free(envval);
+// 	node = make_node(N_COMMAND, export_arg);
+// 	env = new_envs(envp);
+// 	export(node, env);
+//     array = make_env_strs(env);
+//     envs_free(env);
 //     while (array[size] != NULL)
 //     {
 //         printf("%s\n", array[size]);
 //         size++;
 //     }
 // 	free(node);
-//     str_array_free(array); //env_free.c ../src/free.c
+//     str_array_free(array);
 // 	// envs_str_free(env, array);
-// } // ../libft/libft.a
+// }
 
 // __attribute__((destructor))
 // static void destructor() {

--- a/src_resaito/builtin/ft_env.c
+++ b/src_resaito/builtin/ft_env.c
@@ -1,0 +1,61 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_env.c                                           :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: resaito <resaito@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/12/08 15:24:50 by resaito           #+#    #+#             */
+/*   Updated: 2023/12/08 16:57:01 by resaito          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../../inc/minishell.h"
+
+int	ft_env(t_envval *envval)
+{
+	char	**str;
+	size_t	len;
+
+	if (!(envval->env))
+		return (1);
+	str = make_env_strs(envval->env);
+	len = 0;
+	while (str[len])
+	{
+		printf("%s\n", str[len]);
+		len++;
+	}
+	str_array_free(str);
+	return (0);
+}
+
+// t_node	*make_node(enum e_type node_type, char **args)
+// {
+// 	t_node	*node;
+
+// 	node = calloc(sizeof(t_node), 1);
+// 	node->type = node_type;
+// 	node->name = args[0];
+// 	node->args = args;
+// 	return (node);
+// }
+
+// int	main(int ac, char **av, char **envp)
+// {
+// 	// t_node		*node;
+// 	t_envval	*envval;
+// 	// char		*env_arg[] = {"env", NULL};
+
+// 	// node = make_node(N_COMMAND, env_arg);
+// 	envval = make_envval(new_envs(envp)); //make_envval.c make_env.c
+// 	ft_env(envval);
+// 	// free(node);
+// 	envs_free(envval->env); //env_free.c ../src/free.c
+// 	free(envval);
+// } // ../libft/libft.a
+
+// __attribute__((destructor))
+// static void destructor() {
+// 	system("leaks -q a.out");
+// }

--- a/src_resaito/builtin/pwd.c
+++ b/src_resaito/builtin/pwd.c
@@ -6,11 +6,11 @@
 /*   By: resaito <resaito@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/08 13:26:22 by resaito           #+#    #+#             */
-/*   Updated: 2023/12/08 13:26:42 by resaito          ###   ########.fr       */
+/*   Updated: 2023/12/08 16:08:55 by resaito          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "../inc/minishell.h"
+#include "../../inc/minishell.h"
 
 int	pwd(t_envval *envval)
 {

--- a/src_resaito/builtin/unset.c
+++ b/src_resaito/builtin/unset.c
@@ -1,59 +1,48 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   export.c                                           :+:      :+:    :+:   */
+/*   unset.c                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: resaito <resaito@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2023/12/08 13:28:22 by resaito           #+#    #+#             */
-/*   Updated: 2023/12/08 13:30:31 by resaito          ###   ########.fr       */
+/*   Created: 2023/12/08 13:27:05 by resaito           #+#    #+#             */
+/*   Updated: 2023/12/08 16:09:00 by resaito          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "../inc/minishell.h"
+#include "../../inc/minishell.h"
 
-static size_t	len_2_equal(char *str);
-
-int	export(t_node *node, t_envval *envval)
+int	unset(t_node *node, t_envval *envval)
 {
 	size_t	size;
 	t_env	*tmp;
-	size_t	equal_len;
+	t_env	*tmp_back;
 
 	size = 1;
 	while (node->args[size] != NULL)
 	{
-		equal_len = len_2_equal(node->args[size]);
-		if (equal_len == 0)
-			return (1);
 		tmp = envval->env;
-		while (tmp->next && ft_strncmp(tmp->key, node->args[size],
-                equal_len) != 0)
-			tmp = tmp->next;
-		if (ft_strncmp(tmp->key, node->args[size], equal_len) == 0)
+		tmp_back = tmp;
+		while (ft_strcmp(node->args[size], tmp->key) != 0 && tmp->next)
 		{
-			free(tmp->value);
-			tmp->value = ft_strdup(node->args[size] + (equal_len + 1));
+			tmp_back = tmp;
+			tmp = tmp->next;
 		}
+		if (tmp->next)
+		{
+			if (tmp == envval->env)
+				envval->env = tmp->next;
+			else if (tmp->next)
+				tmp_back->next = tmp->next;
+		}
+		else if (ft_strcmp(node->args[size], tmp->key) == 0)
+			tmp_back->next = NULL;
 		else
-			envadd_back(&(envval->env), new_env(node->args[size]));
+			return (1);
+		env_free(tmp);
 		size++;
 	}
 	return (0);
-}
-
-static size_t	len_2_equal(char *str)
-{
-	size_t	len;
-
-	len = 0;
-	if (str == NULL)
-		return (0);
-	while (str[len] != '\0' && str[len] != '=')
-		len++;
-	if (str[len] != '=')
-		return (0);
-	return (len);
 }
 
 // t_node	*make_node(enum e_type node_type, char **args)
@@ -70,25 +59,27 @@ static size_t	len_2_equal(char *str)
 // int	main(int ac, char **av, char **envp)
 // {
 // 	t_node	*node;
-// 	t_env	*env;
+// 	// t_env	*env;
+//     t_envval *envval;
 //     char    **array;
 //     int     size = 0;
-// 	char	*export_arg[] = {"export", "PATH", NULL};
+// 	char	*unset_arg[] = {"export", "$PATH", NULL};
 
-// 	node = make_node(N_COMMAND, export_arg);
-// 	env = new_envs(envp);
-// 	export(node, env);
-//     array = make_env_strs(env);
-//     envs_free(env);
+// 	node = make_node(N_COMMAND, unset_arg);
+// 	envval = make_envval(new_envs(envp)); //make_envval.c make_env.c
+// 	printf("%d\n",unset(node, envval));
+//     array = make_env_strs(envval->env); //make_env.c
+//     envs_free(envval->env); // env_free.c
+//     free(envval);
 //     while (array[size] != NULL)
 //     {
 //         printf("%s\n", array[size]);
 //         size++;
 //     }
 // 	free(node);
-//     str_array_free(array);
+//     str_array_free(array); //env_free.c ../src/free.c
 // 	// envs_str_free(env, array);
-// }
+// } // ../libft/libft.a
 
 // __attribute__((destructor))
 // static void destructor() {

--- a/src_resaito/env_free.c
+++ b/src_resaito/env_free.c
@@ -6,7 +6,7 @@
 /*   By: resaito <resaito@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/01 14:28:49 by resaito           #+#    #+#             */
-/*   Updated: 2023/12/01 15:24:10 by resaito          ###   ########.fr       */
+/*   Updated: 2023/12/08 13:38:38 by resaito          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,13 +16,18 @@ void	envs_free(t_env *env)
 {
 	if (env->next)
 		envs_free(env->next);
-	free(env->key);
-	free(env->value);
-	free(env);
+	env_free(env);
 }
 
 void	envs_str_free(t_env *env, char **str)
 {
 	envs_free(env);
 	str_array_free(str);
+}
+
+void	env_free(t_env *env)
+{
+	free(env->key);
+	free(env->value);
+	free(env);
 }

--- a/src_resaito/exec.c
+++ b/src_resaito/exec.c
@@ -58,6 +58,7 @@ int	execution(t_node *node, bool is_exec_pipe, t_envval *envval)
 
 void	wait_all(t_node *node, t_envval *envval)
 {
+	int status;
 	if (node == NONE)
 		return ;
 	if (node->type == N_PIPE)
@@ -66,7 +67,10 @@ void	wait_all(t_node *node, t_envval *envval)
 		wait_all(node->right, envval);
 	}
 	if (node->type == N_COMMAND)
-		wait(&(envval->status));
+	{
+		wait(&status);
+		envval->status = status >> 8;
+	}
 	return ;
 }
 

--- a/src_resaito/exec.c
+++ b/src_resaito/exec.c
@@ -37,12 +37,13 @@ int	execute_command(t_node *node, bool has_pipe, t_envval *envval)
 }
 
 // #include <stdio.h>
-int	execution(t_node *node, bool is_exec_pipe, t_envval *envval)
+void	execution(t_node *node, bool is_exec_pipe, t_envval *envval)
 {	
 	int	dupout;
+	int status;
 
 	if (node == NONE)
-		return (0);
+		return ;
 	if (node->type == N_PIPE)
 	{
 		execution(node->left, true, envval);
@@ -50,10 +51,15 @@ int	execution(t_node *node, bool is_exec_pipe, t_envval *envval)
 	}
 	if (node->type == N_COMMAND)
 	{
-		dup_2_stdin(node);
+		status = dup_2_stdin(node);
+		if (status != 0)
+		{
+			envval->status = status;
+			return ;
+		}
 		execute_command(node, is_exec_pipe, envval);
 	}
-	return (0);
+	return ;
 }
 
 void	wait_all(t_node *node, t_envval *envval)
@@ -68,7 +74,9 @@ void	wait_all(t_node *node, t_envval *envval)
 	}
 	if (node->type == N_COMMAND)
 	{
+		printf("aa\n");
 		wait(&status);
+		printf("%d\n", status >> 8);
 		envval->status = status >> 8;
 	}
 	return ;

--- a/src_resaito/exec.c
+++ b/src_resaito/exec.c
@@ -75,7 +75,7 @@ void	ft_execution(t_node *node, t_envval *envval)
 	int	dupin;
 
 	dupin = dup(STDIN_FILENO);
-	input_redir(node);
+	input_redir(node, envval);
 	execution(node, false, envval);
 	wait_all(node, envval);
 	// system("leaks -q minishell");
@@ -148,3 +148,4 @@ void	ft_execution(t_node *node, t_envval *envval)
 //     // wait(NULL);
 //     // wait(NULL);
 // }
+

--- a/src_resaito/exec.c
+++ b/src_resaito/exec.c
@@ -74,9 +74,9 @@ void	wait_all(t_node *node, t_envval *envval)
 	}
 	if (node->type == N_COMMAND)
 	{
-		printf("aa\n");
+		// printf("aa\n");
 		wait(&status);
-		printf("%d\n", status >> 8);
+		// printf("%d\n", status >> 8);
 		envval->status = status >> 8;
 	}
 	return ;
@@ -88,7 +88,10 @@ void	ft_execution(t_node *node, t_envval *envval)
 
 	dupin = dup(STDIN_FILENO);
 	input_redir(node, envval);
-	execution(node, false, envval);
+	if (is_single_command(node) && is_builtin(node))
+		exec_builtin(node, envval);
+	else
+		execution(node, false, envval);
 	wait_all(node, envval);
 	// system("leaks -q minishell");
 	dup2(dupin, STDIN_FILENO);

--- a/src_resaito/execution_by_process.c
+++ b/src_resaito/execution_by_process.c
@@ -6,7 +6,7 @@
 /*   By: resaito <resaito@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/04 14:17:03 by resaito           #+#    #+#             */
-/*   Updated: 2023/12/04 14:17:14 by resaito          ###   ########.fr       */
+/*   Updated: 2023/12/08 15:54:31 by resaito          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,6 +15,8 @@
 int child_process(t_node *node, bool has_pipe, t_envval *envval,
 		int pipefd[2])
 {
+	char	**str;
+
 	if (has_pipe)
 	{
 		close(pipefd[0]);
@@ -24,7 +26,9 @@ int child_process(t_node *node, bool has_pipe, t_envval *envval,
 	redir_dup(node);
     if (!node->name)
         exit(print_error(node->args[0], "command not found", 127));
-	execve(node->name, node->args, make_env_strs(envval->env));
+	str = make_env_strs(envval->env);
+	execve(node->name, node->args, str);
+	str_array_free(str);
 	ft_perror(node->name);
     return (0);
 }

--- a/src_resaito/execution_by_process.c
+++ b/src_resaito/execution_by_process.c
@@ -26,11 +26,16 @@ int child_process(t_node *node, bool has_pipe, t_envval *envval,
 	redir_dup(node);
     if (!node->name)
         exit(print_error(node->args[0], "command not found", 127));
-	str = make_env_strs(envval->env);
-	execve(node->name, node->args, str);
-	str_array_free(str);
-	ft_perror(node->name);
-    return (0);
+	if (is_builtin(node))
+		exec_builtin(node, envval);
+	else
+	{
+		str = make_env_strs(envval->env);
+		execve(node->name, node->args, str);
+		str_array_free(str);
+		ft_perror(node->name);
+	}
+    exit (-1);
 }
 
 void	parent_process(bool has_pipe, int pipefd[2])

--- a/src_resaito/execution_by_process.c
+++ b/src_resaito/execution_by_process.c
@@ -12,7 +12,7 @@
 
 #include "../inc/minishell.h"
 
-void	child_process(t_node *node, bool has_pipe, t_envval *envval,
+int child_process(t_node *node, bool has_pipe, t_envval *envval,
 		int pipefd[2])
 {
 	if (has_pipe)
@@ -22,8 +22,11 @@ void	child_process(t_node *node, bool has_pipe, t_envval *envval,
 		close(pipefd[1]);
 	}
 	redir_dup(node);
+    if (!node->name)
+        exit(print_error(node->args[0], "command not found", 127));
 	execve(node->name, node->args, make_env_strs(envval->env));
 	ft_perror(node->name);
+    return (0);
 }
 
 void	parent_process(bool has_pipe, int pipefd[2])

--- a/src_resaito/export.c
+++ b/src_resaito/export.c
@@ -1,46 +1,59 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   export.c                                           :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: resaito <resaito@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/12/08 13:28:22 by resaito           #+#    #+#             */
+/*   Updated: 2023/12/08 13:30:31 by resaito          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
 #include "../inc/minishell.h"
 
-static size_t  len_2_equal(char *str);
+static size_t	len_2_equal(char *str);
 
-int export(t_node *node, t_envval *envval)
+int	export(t_node *node, t_envval *envval)
 {
-    size_t  size;
-    t_env   *tmp;
-    size_t  equal_len;
+	size_t	size;
+	t_env	*tmp;
+	size_t	equal_len;
 
-    size = 1;
-    while (node->args[size] != NULL)
-    {
-        equal_len = len_2_equal(node->args[size]);
-        if (equal_len == 0)
-            return (1);
-        tmp = envval->env;
-        while (tmp->next && ft_strncmp(tmp->key, node->args[size], equal_len) != 0)
-            tmp = tmp->next;
-        if (ft_strncmp(tmp->key, node->args[size], equal_len) == 0)
-        {
-            free(tmp->value);
-            tmp->value = ft_strdup(node->args[size] + (equal_len + 1));
-        }
-        else
-            envadd_back(&(envval->env), new_env(node->args[size]));
-        size++;
-    }
-    return (0);
+	size = 1;
+	while (node->args[size] != NULL)
+	{
+		equal_len = len_2_equal(node->args[size]);
+		if (equal_len == 0)
+			return (1);
+		tmp = envval->env;
+		while (tmp->next && ft_strncmp(tmp->key, node->args[size],
+                equal_len) != 0)
+			tmp = tmp->next;
+		if (ft_strncmp(tmp->key, node->args[size], equal_len) == 0)
+		{
+			free(tmp->value);
+			tmp->value = ft_strdup(node->args[size] + (equal_len + 1));
+		}
+		else
+			envadd_back(&(envval->env), new_env(node->args[size]));
+		size++;
+	}
+	return (0);
 }
 
-static size_t  len_2_equal(char *str)
+static size_t	len_2_equal(char *str)
 {
-    size_t  len;
+	size_t	len;
 
-    len = 0;
-    if (str == NULL)
-        return (0);
-    while (str[len] != '\0' && str[len] != '=')
-        len++;
-    if (str[len] != '=')
-        return (0);
-    return (len);
+	len = 0;
+	if (str == NULL)
+		return (0);
+	while (str[len] != '\0' && str[len] != '=')
+		len++;
+	if (str[len] != '=')
+		return (0);
+	return (len);
 }
 
 // t_node	*make_node(enum e_type node_type, char **args)

--- a/src_resaito/ft_env.c
+++ b/src_resaito/ft_env.c
@@ -1,0 +1,61 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_env.c                                           :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: resaito <resaito@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/12/08 15:24:50 by resaito           #+#    #+#             */
+/*   Updated: 2023/12/08 15:55:22 by resaito          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../inc/minishell.h"
+
+int	ft_env(t_envval *envval)
+{
+	char	**str;
+	size_t	len;
+
+	if (!(envval->env))
+		return (1);
+	str = make_env_strs(envval->env);
+	len = 0;
+	while (str[len])
+	{
+		printf("%s\n", str[len]);
+		len++;
+	}
+    str_array_free(str);
+	return (0);
+}
+
+// t_node	*make_node(enum e_type node_type, char **args)
+// {
+// 	t_node	*node;
+
+// 	node = calloc(sizeof(t_node), 1);
+// 	node->type = node_type;
+// 	node->name = args[0];
+// 	node->args = args;
+// 	return (node);
+// }
+
+// int	main(int ac, char **av, char **envp)
+// {
+// 	// t_node		*node;
+// 	t_envval	*envval;
+// 	// char		*env_arg[] = {"env", NULL};
+
+// 	// node = make_node(N_COMMAND, env_arg);
+// 	envval = make_envval(new_envs(envp)); //make_envval.c make_env.c
+// 	ft_env(envval);
+// 	// free(node);
+// 	envs_free(envval->env); //env_free.c ../src/free.c
+// 	free(envval);
+// } // ../libft/libft.a
+
+// __attribute__((destructor))
+// static void destructor() {
+// 	system("leaks -q a.out");
+// }

--- a/src_resaito/input_redir.c
+++ b/src_resaito/input_redir.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   input_redir.c                                      :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: resaito <resaito@student.42.fr>            +#+  +:+       +#+        */
+/*   By: resaito <resaito@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/29 14:28:11 by resaito           #+#    #+#             */
-/*   Updated: 2023/11/29 14:40:20 by resaito          ###   ########.fr       */
+/*   Updated: 2023/12/08 13:35:41 by resaito          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -52,13 +52,13 @@ int	dup_2_stdin(t_node *node)
 		if (is_type_heredoc(redir) || is_type_indirect(redir))
 		{
 			if (redir->fd == -1)
-				return print_error(redir->file[0], "No such file or directory", 1);
+				return (print_error(redir->file[0], "No such file or directory", 1));
 			dup2(redir->fd, STDIN_FILENO);
 			close(redir->fd);
 		}
 		redir = redir->next;
 	}
-	return 0;
+	return (0);
 }
 
 bool	is_type_heredoc(t_redir *redir)

--- a/src_resaito/input_redir.c
+++ b/src_resaito/input_redir.c
@@ -40,22 +40,25 @@ int	input_redir(t_node *node, t_envval *envval)
 	return (0);
 }
 
-void	dup_2_stdin(t_node *node)
+int	dup_2_stdin(t_node *node)
 {
 	t_redir	*redir;
 
 	if (node->redir == NULL)
-		return ;
+		return (0);
 	redir = node->redir;
 	while (redir != NULL)
 	{
 		if (is_type_heredoc(redir) || is_type_indirect(redir))
 		{
+			if (redir->fd == -1)
+				return print_error(redir->file[0], "No such file or directory", 1);
 			dup2(redir->fd, STDIN_FILENO);
 			close(redir->fd);
 		}
 		redir = redir->next;
 	}
+	return 0;
 }
 
 bool	is_type_heredoc(t_redir *redir)

--- a/src_resaito/input_redir.c
+++ b/src_resaito/input_redir.c
@@ -14,7 +14,7 @@
 #include <errno.h>
 #include <string.h>
 
-int	input_redir(t_node *node)
+int	input_redir(t_node *node, t_envval *envval)
 {
 	t_redir	*redir;
 
@@ -22,8 +22,8 @@ int	input_redir(t_node *node)
 		return (0);
 	if (node->type == N_PIPE)
 	{
-		input_redir(node->left);
-		input_redir(node->right);
+		input_redir(node->left, envval);
+		input_redir(node->right, envval);
 	}
 	if (node->type == N_COMMAND)
 	{
@@ -31,7 +31,7 @@ int	input_redir(t_node *node)
 		while (redir != NULL)
 		{
 			if (is_type_heredoc(redir))
-				redir->fd = heredoc_exec(redir);
+				redir->fd = heredoc_exec(redir, envval);
 			if (is_type_indirect(redir))
 				redir->fd = open(redir->file[0], O_RDONLY);
 			redir = redir->next;

--- a/src_resaito/is_single_command.c
+++ b/src_resaito/is_single_command.c
@@ -1,0 +1,8 @@
+#include "../inc/minishell.h"
+
+bool    is_single_command(t_node *node)
+{
+    if (node->type == N_COMMAND)
+        return (true);
+    return (false);
+}

--- a/src_resaito/print_error.c
+++ b/src_resaito/print_error.c
@@ -1,0 +1,10 @@
+#include "../inc/minishell.h"
+
+int print_error(char *command, char *error, int status)
+{
+    ft_putstr_fd("minishell: ", STDERR_FILENO);
+    ft_putstr_fd(command, STDERR_FILENO);
+    ft_putstr_fd(": ", STDERR_FILENO);
+    ft_putendl_fd(error, STDERR_FILENO);
+    return (status);
+}

--- a/src_resaito/print_error.c
+++ b/src_resaito/print_error.c
@@ -1,10 +1,22 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   print_error.c                                      :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: resaito <resaito@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/12/08 13:31:19 by resaito           #+#    #+#             */
+/*   Updated: 2023/12/08 13:31:40 by resaito          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
 #include "../inc/minishell.h"
 
-int print_error(char *command, char *error, int status)
+int	print_error(char *command, char *error, int status)
 {
-    ft_putstr_fd("minishell: ", STDERR_FILENO);
-    ft_putstr_fd(command, STDERR_FILENO);
-    ft_putstr_fd(": ", STDERR_FILENO);
-    ft_putendl_fd(error, STDERR_FILENO);
-    return (status);
+	ft_putstr_fd("minishell: ", STDERR_FILENO);
+	ft_putstr_fd(command, STDERR_FILENO);
+	ft_putstr_fd(": ", STDERR_FILENO);
+	ft_putendl_fd(error, STDERR_FILENO);
+	return (status);
 }

--- a/src_resaito/pwd.c
+++ b/src_resaito/pwd.c
@@ -1,14 +1,26 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   pwd.c                                              :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: resaito <resaito@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/12/08 13:26:22 by resaito           #+#    #+#             */
+/*   Updated: 2023/12/08 13:26:42 by resaito          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
 #include "../inc/minishell.h"
 
-int pwd(t_envval *envval)
+int	pwd(t_envval *envval)
 {
-    t_env   *tmp;
+	t_env	*tmp;
 
-    tmp = envval->env;
-    while (ft_strcmp(tmp->key, "PWD") != 0 && tmp->next)
-        tmp = tmp->next;
-    if (!(tmp->next))
-        return (1);
-    ft_putendl_fd(tmp->value, STDOUT_FILENO);
-    return (0);
+	tmp = envval->env;
+	while (ft_strcmp(tmp->key, "PWD") != 0 && tmp->next)
+		tmp = tmp->next;
+	if (!(tmp->next))
+		return (1);
+	ft_putendl_fd(tmp->value, STDOUT_FILENO);
+	return (0);
 }

--- a/src_resaito/redirect_dup.c
+++ b/src_resaito/redirect_dup.c
@@ -13,6 +13,8 @@
 #include "../inc/minishell.h"
 #include "../inc/expansion.h"
 
+char	*expand_parameter(char *token, t_envval *envval);
+
 int	redir_dup(t_node *node)
 {
 	int	out_fd;
@@ -38,7 +40,7 @@ int	redir_dup(t_node *node)
 	return (0);
 }
 
-int	heredoc_exec(t_redir *redir)
+int	heredoc_exec(t_redir *redir, t_envval *envval)
 {
 	char	*line;
 	int		pipefd[2];
@@ -59,7 +61,7 @@ int	heredoc_exec(t_redir *redir)
 			close(pipefd[1]);
 			break ;
 		}
-		line = expand_parameter(line);
+		line = expand_parameter(line, envval);
 		ft_putendl_fd(line, pipefd[1]);
 		free(line);
 	}

--- a/src_resaito/search_path.c
+++ b/src_resaito/search_path.c
@@ -21,6 +21,8 @@ char	*search_path(const char *filename)
 	char	*value;
 	char	*end;
 
+	if (access(filename, X_OK) == 0)
+		return able_to_access((char *)filename);
 	value = getenv("PATH");
 	while (value)
 	{

--- a/src_resaito/search_path.c
+++ b/src_resaito/search_path.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   search_path.c                                      :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: resaito <resaito@student.42.fr>            +#+  +:+       +#+        */
+/*   By: resaito <resaito@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/27 12:40:54 by resaito           #+#    #+#             */
-/*   Updated: 2023/10/27 17:13:14 by resaito          ###   ########.fr       */
+/*   Updated: 2023/12/08 13:31:57 by resaito          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,7 +22,7 @@ char	*search_path(const char *filename)
 	char	*end;
 
 	if (access(filename, X_OK) == 0)
-		return able_to_access((char *)filename);
+		return (able_to_access((char *)filename));
 	value = getenv("PATH");
 	while (value)
 	{

--- a/src_resaito/unset.c
+++ b/src_resaito/unset.c
@@ -1,38 +1,48 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   unset.c                                            :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: resaito <resaito@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/12/08 13:27:05 by resaito           #+#    #+#             */
+/*   Updated: 2023/12/08 13:51:17 by resaito          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
 #include "../inc/minishell.h"
 
-int unset(t_node *node, t_envval *envval)
+int	unset(t_node *node, t_envval *envval)
 {
-    size_t size;
-    t_env *tmp;
-    t_env *tmp_back;
+	size_t	size;
+	t_env	*tmp;
+	t_env	*tmp_back;
 
-    size = 1;
-    while (node->args[size] != NULL)
-    {
-        tmp = envval->env;
-        tmp_back = tmp;
-        while (ft_strcmp(node->args[size], tmp->key) != 0 && tmp->next)
-        {
-            tmp_back = tmp;
-            tmp = tmp->next;
-        }
-        if (tmp->next)
-        {
-            if (tmp == envval->env)
-                envval->env = tmp->next;
-            else if (tmp->next)
-                tmp_back->next = tmp->next;
-        }
-        else if (ft_strcmp(node->args[size], tmp->key) == 0)
-            tmp_back->next = NULL;
-        else
-            return (1);
-        free(tmp->key);
-        free(tmp->value);
-        free(tmp);
-        size++;
-    }
-    return (0);
+	size = 1;
+	while (node->args[size] != NULL)
+	{
+		tmp = envval->env;
+		tmp_back = tmp;
+		while (ft_strcmp(node->args[size], tmp->key) != 0 && tmp->next)
+		{
+			tmp_back = tmp;
+			tmp = tmp->next;
+		}
+		if (tmp->next)
+		{
+			if (tmp == envval->env)
+				envval->env = tmp->next;
+			else if (tmp->next)
+				tmp_back->next = tmp->next;
+		}
+		else if (ft_strcmp(node->args[size], tmp->key) == 0)
+			tmp_back->next = NULL;
+		else
+			return (1);
+		env_free(tmp);
+		size++;
+	}
+	return (0);
 }
 
 // t_node	*make_node(enum e_type node_type, char **args)


### PR DESCRIPTION
## builtinを実行する
execをで実行するわけにはいかないので、色々工夫が必要
builtinコマンドだけの場合とパイプがある時とで挙動が変わるのでそれに合わせた。
単体の時
```
if (is_single_command(node) && is_builtin(node))
		exec_builtin(node, envval);
else
		execution(node, false, envval);
```
単体の時は子プロセスに入る前に実行する。

パイプがある時
```
	if (is_builtin(node))
		exec_builtin(node, envval);
	else
	{
		str = make_env_strs(envval->env);
		execve(node->name, node->args, str);
		str_array_free(str);
		ft_perror(node->name);
	}
```
子プロセスでbuiltinか判別して実行する
これにより
```
minishell $ env | grep PATH
```
```
PATH=/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/X11/bin:/Users/saitoureina/Library/Python/3.9/bin:/opt/homebrew/bin:/Users/saitoureina/Library/Python/3.9/bin:/opt/homebrew/bin
minishell $ 
```
ができるようになっている

## #16 に対応
実行前にif文とエラー文を追加しました。
```
minishell $ cat < hoge << fuga
> aaaa
> fuga
minishell: hoge: No such file or directory
minishell $
```

## bad addressの対応
execの前にif文とエラー文を追加しました。
```
minishell $ aaaa
minishell: aaaa: command not found
minishell $ 
```