### PR TITLE
issue対応

### DIFF
--- a/builtins/export.c
+++ b/builtins/export.c
@@ -3,42 +3,38 @@
 /*                                                        :::      ::::::::   */
 /*   export.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: fwatanab <fwatanab@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*   By: resaito <resaito@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/08 13:28:22 by resaito           #+#    #+#             */
-/*   Updated: 2023/12/11 18:52:49 by fwatanab         ###   ########.fr       */
+/*   Updated: 2023/12/12 15:07:52 by resaito          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../inc/builtins.h"
 
 static size_t	len_2_equal(char *str);
+static void		print_export(t_node *node, t_env *env);
+static int		single_export(char *arg, t_envval *envval);
+static int		print_error_export(char *str);
 
 int	export(t_node *node, t_envval *envval)
 {
 	size_t	size;
-	t_env	*tmp;
-	size_t	equal_len;
 
+	if (!envval)
+		return (0);
+	if (!envval->env)
+		return (0);
 	size = 1;
 	while (node->args[size] != NULL)
 	{
-		equal_len = len_2_equal(node->args[size]);
-		if (equal_len == 0)
+		if (print_error_export(node->args[size]))
 			return (1);
-		tmp = envval->env;
-		while (tmp->next && ft_strncmp(tmp->key, node->args[size],
-				equal_len) != 0)
-			tmp = tmp->next;
-		if (ft_strncmp(tmp->key, node->args[size], equal_len) == 0)
-		{
-			free(tmp->value);
-			tmp->value = ft_strdup(node->args[size] + (equal_len + 1));
-		}
-		else
-			envadd_back(&(envval->env), new_env(node->args[size]));
+		if (single_export(node->args[size], envval))
+			return (0);
 		size++;
 	}
+	print_export(node, envval->env);
 	return (0);
 }
 
@@ -56,6 +52,64 @@ static size_t	len_2_equal(char *str)
 	return (len);
 }
 
+static void	print_export(t_node *node, t_env *env)
+{
+	t_env	*tmp;
+
+	if (node->args[1])
+		return ;
+	tmp = env;
+	while (tmp != NULL)
+	{
+		ft_putstr_fd("declare -x ", STDOUT_FILENO);
+		ft_putstr_fd(tmp->key, STDOUT_FILENO);
+		ft_putstr_fd("=\"", STDOUT_FILENO);
+		ft_putstr_fd(tmp->value, STDOUT_FILENO);
+		ft_putendl_fd("\"", STDOUT_FILENO);
+		tmp = tmp->next;
+	}
+}
+
+static int	single_export(char *arg, t_envval *envval)
+{
+	t_env	*tmp;
+	size_t	equal_len;
+
+	equal_len = len_2_equal(arg);
+	if (equal_len == 0)
+		return (1);
+	tmp = envval->env;
+	while (tmp->next && ft_strncmp(tmp->key, arg,
+			equal_len) != 0)
+		tmp = tmp->next;
+	if (ft_strncmp(tmp->key, arg, equal_len) == 0)
+	{
+		free(tmp->value);
+		tmp->value = ft_strdup(arg + (equal_len + 1));
+	}
+	else
+		envadd_back(&(envval->env), new_env(arg));
+	return (0);
+}
+
+static int	print_error_export(char *str)
+{
+	bool	is_error;
+
+	is_error = false;
+	if ((str[0] >= '0' && str[0] <= '9') || str[0] == '=')
+		is_error = true;
+	if (ft_strchr(str, '$') || ft_strchr(str, '/') || ft_strchr(str, '#')
+		|| ft_strchr(str, ';'))
+		is_error = true;
+	if (!is_error)
+		return (0);
+	ft_putstr_fd("minishell: export: `", STDERR_FILENO);
+	ft_putstr_fd(str, STDERR_FILENO);
+	ft_putendl_fd("': not a valid identififer", STDERR_FILENO);
+	return (1);
+}
+
 // t_node	*make_node(enum e_type node_type, char **args)
 // {
 // 	t_node	*node;
@@ -70,23 +124,24 @@ static size_t	len_2_equal(char *str)
 // int	main(int ac, char **av, char **envp)
 // {
 // 	t_node	*node;
-// 	t_env	*env;
+// 	t_envval	*envval;
 //     char    **array;
 //     int     size = 0;
-// 	char	*export_arg[] = {"export", "PATH", NULL};
+// 	char	*export_arg[] = {"export", NULL};
 
 // 	node = make_node(N_COMMAND, export_arg);
-// 	env = new_envs(envp);
-// 	export(node, env);
-//     array = make_env_strs(env);
-//     envs_free(env);
-//     while (array[size] != NULL)
-//     {
-//         printf("%s\n", array[size]);
-//         size++;
-//     }
+// 	envval = make_envval(new_envs(envp));
+// 	export(node, NULL);
+//     // array = make_env_strs(envval->env);
+//     envs_free(envval->env);
+// 	free(envval);
+//     // while (array[size] != NULL)
+//     // {
+//     //     printf("%s\n", array[size]);
+//     //     size++;
+//     // }
 // 	free(node);
-//     str_array_free(array);
+//     // str_array_free(array);
 // 	// envs_str_free(env, array);
 // }
 

--- a/inc/builtins.h
+++ b/inc/builtins.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   builtins.h                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: fwatanab <fwatanab@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*   By: resaito <resaito@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/07 09:47:55 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/12/11 20:01:54 by fwatanab         ###   ########.fr       */
+/*   Updated: 2023/12/12 14:11:57 by resaito          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,6 +14,7 @@
 # define BUILTINS_H
 
 # include "minishell.h"
+# include <stdbool.h>
 
 typedef struct s_node	t_node;
 typedef struct s_envval	t_envval;

--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -3,26 +3,26 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: fwatanab <fwatanab@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*   By: resaito <resaito@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/18 21:17:45 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/12/11 20:03:17 by fwatanab         ###   ########.fr       */
+/*   Updated: 2023/12/12 12:52:11 by resaito          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef MINISHELL_H
 # define MINISHELL_H
 
+# include "../inc/builtins.h"
 # include "../libft/inc/libft.h"
 # include "../libft/inc/libft_utils.h"
-# include <stdio.h>
-# include <readline/readline.h>
-# include <readline/history.h>
-# include <stddef.h>
-# include <fcntl.h>
 # include "lexer_parser_utils.h"
+# include <fcntl.h>
+# include <readline/history.h>
+# include <readline/readline.h>
 # include <signal.h>
-# include "../inc/builtins.h"
+# include <stddef.h>
+# include <stdio.h>
 
 # define MINISHELL "minishell $ "
 # define SPACE ' '
@@ -34,13 +34,13 @@
 # define REDIR_HIRE "<<"
 # define REDIR_APPEND ">>"
 
-extern int	sig_status;
+extern int				sig_status;
 
 typedef struct s_token_list
 {
 	char				*token;
 	struct s_token_list	*next;
-}	t_token_list;
+}						t_token_list;
 
 typedef enum e_type
 {
@@ -51,100 +51,102 @@ typedef enum e_type
 	N_REDIR_HERE,
 	N_REDIR_APPEND,
 	N_PIPE
-}	t_type;
+}						t_type;
 
 typedef struct s_redir
 {
-	enum e_type		type;
-	char			**file;
-	int				fd;
-	struct s_redir	*next;
-}	t_redir;
+	enum e_type			type;
+	char				**file;
+	int					fd;
+	struct s_redir		*next;
+}						t_redir;
 
 typedef struct s_node
 {
-	enum e_type		type;
-	char			*name;
-	char			**args;
-	struct s_redir	*redir;
-	struct s_node	*left;
-	struct s_node	*right;
-}	t_node;
+	enum e_type			type;
+	char				*name;
+	char				**args;
+	struct s_redir		*redir;
+	struct s_node		*left;
+	struct s_node		*right;
+}						t_node;
 
 typedef struct s_env
 {
-	char			*key;
-	char			*value;
-	struct s_env	*next;
-}	t_env;
+	char				*key;
+	char				*value;
+	struct s_env		*next;
+}						t_env;
 
 typedef struct s_envval
 {
-	t_env	*env;
-	int		status;
-}	t_envval;
+	t_env				*env;
+	int					status;
+}						t_envval;
 
 //lexer parser
-t_token_list	*tokenize(const char *str);
-void			check_token(t_token_list *list);
-t_node			*parser_start(t_token_list **list);
-t_node			*parser(t_node *node, t_token_list **list, t_parse_check *key);
-t_redir			*redir_parse(t_node *node, t_redir *redir, \
-		t_token_list **list, char *token);
+t_token_list			*tokenize(const char *str);
+void					check_token(t_token_list *list);
+t_node					*parser_start(t_token_list **list, t_env *env);
+t_node					*parser(t_node *node, t_token_list **list,
+							t_parse_check *key, t_env *env);
+t_redir					*redir_parse(t_node *node, t_redir *redir,
+							t_token_list **list, char *token);
 
 //expansion
-void			check_exp(t_node *node, t_envval *envval);
+void					check_exp(t_node *node, t_envval *envval);
 
 //signal
-void			signal_handler(int sig);
-void			signal_fork_handler(int sig);
-void			check_status(t_envval *envval);
+void					signal_handler(int sig);
+void					signal_fork_handler(int sig);
+void					check_status(t_envval *envval);
 
 //free
-void			list_free(t_token_list **list);
-void			str_array_free(char **array);
-void			node_free(t_node *node);
-void			redir_free(t_redir *redir);
+void					list_free(t_token_list **list);
+void					str_array_free(char **array);
+void					node_free(t_node *node);
+void					redir_free(t_redir *redir);
 
 //error
-void			malloc_error(void);
+void					malloc_error(void);
 
 //resaito search_path
-char			*search_path(const char *filename);
+char					*search_path(const char *filename, t_env *env);
 
 // exec
-void			execution(t_node *node, bool is_exec_pipe, t_envval *envval);
-void			ft_execution(t_node *node, t_envval *envval);
-int				child_process(t_node *node, bool has_pipe, t_envval *envval,
-					int pipefd[2]);
-void			parent_process(bool has_pipe, int pipefd[2]);
+void					execution(t_node *node, bool is_exec_pipe,
+							t_envval *envval);
+void					ft_execution(t_node *node, t_envval *envval);
+int						child_process(t_node *node, bool has_pipe,
+							t_envval *envval, int pipefd[2]);
+void					parent_process(bool has_pipe, int pipefd[2]);
 
 // redir
-int				redir_dup(t_node *node);
-int				indirect_exec(t_node *node);
-int				heredoc_exec(t_redir *redir, t_envval *envval);
-int				input_redir(t_node *node, t_envval *envval);
-bool			is_type_heredoc(t_redir *redir);
-bool			is_type_indirect(t_redir *redir);
-int				dup_2_stdin(t_node *node);
+int						redir_dup(t_node *node);
+int						indirect_exec(t_node *node);
+int						heredoc_exec(t_redir *redir, t_envval *envval);
+int						input_redir(t_node *node, t_envval *envval);
+bool					is_type_heredoc(t_redir *redir);
+bool					is_type_indirect(t_redir *redir);
+int						dup_2_stdin(t_node *node);
 
 // env
-t_env			*new_envs(char **envp);
-void			envadd_back(t_env **env, t_env *new);
-t_env			*new_env(char *envp);
-char			**make_env_strs(t_env *env);
-size_t			ft_list_size(t_env *env);
-void			envs_free(t_env *env);
-void			envs_str_free(t_env *env, char **str);
-void			env_free(t_env *env);
-t_envval		*make_envval(t_env *env);
+t_env					*new_envs(char **envp);
+void					envadd_back(t_env **env, t_env *new);
+t_env					*new_env(char *envp);
+char					**make_env_strs(t_env *env);
+size_t					ft_list_size(t_env *env);
+void					envs_free(t_env *env);
+void					envs_str_free(t_env *env, char **str);
+void					env_free(t_env *env);
+t_envval				*make_envval(t_env *env);
 
 // utils
-void			*ft_xmalloc(size_t size);
-void			ft_perror(char *str);
-int				ft_pipe(int pipefd[2]);
-int				print_error(char *command, char *error, int status);
-bool			is_single_command(t_node *node);
-int				get_exit_code(int n);
+void					*ft_xmalloc(size_t size);
+void					ft_perror(char *str);
+int						ft_pipe(int pipefd[2]);
+int						print_error(char *command, char *error, int status);
+bool					is_single_command(t_node *node);
+int						get_exit_code(int n);
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: fwatanab <fwatanab@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*   By: resaito <resaito@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/18 21:17:52 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/12/12 11:11:11 by fwatanab         ###   ########.fr       */
+/*   Updated: 2023/12/12 12:09:42 by resaito          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,7 +21,7 @@ void	minishell(char *line, t_envval *envval)
 	list = tokenize(line);
 	tmp = list;
 	check_token(list);
-	node = parser_start(&list);
+	node = parser_start(&list, envval->env);
 	check_exp(node, envval);
 	list_free(&tmp);
 	ft_execution(node, envval);

--- a/src/parser.c
+++ b/src/parser.c
@@ -6,14 +6,14 @@
 /*   By: resaito <resaito@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/25 19:19:00 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/12/11 16:45:39 by resaito          ###   ########.fr       */
+/*   Updated: 2023/12/12 12:45:09 by resaito          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../inc/minishell.h"
 
 static bool	updata_type_value(t_node *node, \
-		t_token_list **list, t_parse_check *key)
+		t_token_list **list, t_parse_check *key, t_env *env)
 {
 	t_token_list	*tmp;
 
@@ -33,25 +33,25 @@ static bool	updata_type_value(t_node *node, \
 	{
 		tmp = key->key_list;
 		check_right_node(node);
-		node->right = parser(node->right, &tmp, key);
+		node->right = parser(node->right, &tmp, key, env);
 		return (false);
 	}
 	return (true);
 }
 
-static void	updata_name_value(t_node *node, t_parse_check *key)
+static void	updata_name_value(t_node *node, t_parse_check *key, t_env *env)
 {
 	if (key->key_type)
 	{
 		if (!node->right->name)
-			node->right->name = search_path(key->token);
+			node->right->name = search_path(key->token, env);
 		node->right->type = N_COMMAND;
 		node->right->args = add_array(node->right->args, key->token);
 	}
 	else if (!key->key_type)
 	{
 		if (!node->left->name)
-			node->left->name = search_path(key->token);
+			node->left->name = search_path(key->token, env);
 		node->left->type = N_COMMAND;
 		node->left->args = add_array(node->left->args, key->token);
 	}
@@ -73,7 +73,8 @@ static bool	redir_checker(t_node *node, t_parse_check *key, t_token_list **list)
 	return (false);
 }
 
-t_node	*parser(t_node *node, t_token_list **list, t_parse_check *key)
+t_node	*parser(t_node *node, t_token_list **list, t_parse_check *key,
+		t_env *env)
 {
 	all_node_init(node);
 	if (!node)
@@ -86,13 +87,13 @@ t_node	*parser(t_node *node, t_token_list **list, t_parse_check *key)
 			return (NULL);
 		if (ft_strcmp(key->token, "|") == 0)
 		{
-			if (updata_type_value(node, list, key) == false)
+			if (updata_type_value(node, list, key, env) == false)
 				break ;
 		}
 		else
 		{
 			if (redir_checker(node, key, list) == false)
-				updata_name_value(node, key);
+				updata_name_value(node, key, env);
 		}
 	}
 	if (node->type == NONE)
@@ -100,7 +101,7 @@ t_node	*parser(t_node *node, t_token_list **list, t_parse_check *key)
 	return (node);
 }
 
-t_node	*parser_start(t_token_list **list)
+t_node	*parser_start(t_token_list **list, t_env *env)
 {
 	t_node			*node;
 	t_parse_check	*key;
@@ -111,7 +112,7 @@ t_node	*parser_start(t_token_list **list)
 	key = (t_parse_check *)ft_calloc(sizeof(t_parse_check), 1);
 	if (!key)
 		return (NULL);
-	node = parser(node, list, key);
+	node = parser(node, list, key, env);
 	free(key);
 	return (node);
 }

--- a/src_resaito/execution_by_process.c
+++ b/src_resaito/execution_by_process.c
@@ -6,11 +6,13 @@
 /*   By: resaito <resaito@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/04 14:17:03 by resaito           #+#    #+#             */
-/*   Updated: 2023/12/11 12:56:37 by resaito          ###   ########.fr       */
+/*   Updated: 2023/12/12 12:40:33 by resaito          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../inc/minishell.h"
+
+static t_env	*ft_getpath(t_env *env);
 
 int	child_process(t_node *node, bool has_pipe, t_envval *envval, int pipefd[2])
 {
@@ -23,8 +25,10 @@ int	child_process(t_node *node, bool has_pipe, t_envval *envval, int pipefd[2])
 		close(pipefd[1]);
 	}
 	redir_dup(node);
-	if (!node->name)
+	if (!node->name && ft_getpath(envval->env))
 		exit(print_error(node->args[0], "command not found", 127));
+	else if (!ft_getpath(envval->env))
+		exit(print_error(node->args[0], "No such file or directory", 127));
 	if (is_builtin(node))
 		exec_builtin(node, envval);
 	else
@@ -45,4 +49,16 @@ void	parent_process(bool has_pipe, int pipefd[2])
 		dup2(pipefd[0], STDIN_FILENO);
 		close(pipefd[0]);
 	}
+}
+
+static t_env	*ft_getpath(t_env *env)
+{
+	t_env	*tmp;
+
+	tmp = env;
+	while (tmp && ft_strcmp(tmp->key, "PATH") != 0)
+		tmp = tmp->next;
+	if (tmp == NULL)
+		return (NULL);
+	return (tmp);
 }

--- a/src_resaito/search_path.c
+++ b/src_resaito/search_path.c
@@ -6,16 +6,16 @@
 /*   By: resaito <resaito@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/27 12:40:54 by resaito           #+#    #+#             */
-/*   Updated: 2023/12/08 13:31:57 by resaito          ###   ########.fr       */
+/*   Updated: 2023/12/12 12:16:39 by resaito          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../inc/minishell.h"
+#include "../inc/expansion.h"
 
-char	*search_path(const char *filename);
-char	*able_to_access(char *path);
+static char	*able_to_access(char *path);
 
-char	*search_path(const char *filename)
+char	*search_path(const char *filename, t_env *env)
 {
 	char	path[PATH_MAX];
 	char	*value;
@@ -23,7 +23,7 @@ char	*search_path(const char *filename)
 
 	if (access(filename, X_OK) == 0)
 		return (able_to_access((char *)filename));
-	value = getenv("PATH");
+	value = ft_getenv("PATH", env);
 	while (value)
 	{
 		ft_bzero(path, PASS_MAX);
@@ -43,7 +43,7 @@ char	*search_path(const char *filename)
 	return (NULL);
 }
 
-char	*able_to_access(char *path)
+static char	*able_to_access(char *path)
 {
 	char	*dup;
 


### PR DESCRIPTION
## やったこと
search_pathのgetenv()をft_getenv()に変更
exportの挙動をbashをもとに変更

## search_path
get_env()からft_getenv()に変えたことでヘッダーとsrcの引数を書き換え
このまま実行すると
```
minishell $ unset PATH
minishell $ ls
minishell: ls: command not found
minishell $
```
bashの表示とは異なる
```
bash-3.2$ unset PATH
bash-3.2$ ls
bash: ls: No such file or directory
bash-3.2$
```
execの方でif文を追加してbashの挙動に合わせた
```
minishell $ aaa
minishell: aaa: command not found
minishell $ unset PATH
minishell $ ls
minishell: ls: No such file or directory
minishell $ aaa
minishell: aaa: No such file or directory
```
bash
```
bash-3.2$ aaa
bash: aaa: command not found
bash-3.2$ unset PATH
bash-3.2$ ls
bash: ls: No such file or directory
bash-3.2$ aaa
bash: aaa: No such file or directory
bash-3.2$
```
## export
引数がないときにプリントされるように変更
```
minishell $ export
declare -x TMPDIR="/var/folders/zz/zyxvpxvq6csfxvn_n000137h0008sw/T/"
declare -x __CF_USER_TEXT_ENCODING="0x233C:0x1:0xE"
declare -x HOME="/Users/resaito"
declare -x SHELL="/bin/zsh"
declare -x Apple_PubSub_Socket_Render="/private/tmp/com.apple.launchd.xgkCF0FpCL/Render"
declare -x SSH_AUTH_SOCK="/private/tmp/com.apple.launchd.JR5urchWO1/Listeners"
~
```
引数に特定の文字が来る時のエラーを追加
```
minishell $ export =
minishell: export: `=': not a valid identififer
minishell $ export 1aaa
minishell: export: `1aaa': not a valid identififer
minishell $ export /
minishell: export: `/': not a valid identififer
```
環境変数がNULLの時に対応
if文で