### PR TITLE
リダイレクトのparserの挙動修正 / コマンドがスペースの時のセグフォ修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ NAME	= minishell
 
 SRCSDIR	= src/
 
-SRCS = main.c free.c tokenize.c check_token.c parser.c redir_parser.c parser_utils.c lexer_parser_init.c expansion.c exp_init.c expand_parameter.c expand_utils.c signal.c print.c
+SRCS = main.c free.c check_line.c tokenize.c check_token.c parser.c redir_parser.c parser_utils.c lexer_parser_init.c expansion.c exp_init.c expand_parameter.c expand_utils.c signal.c print.c
 
 RE_SRCSDIR	= src_resaito/
 
@@ -32,7 +32,7 @@ RE_OBJS	= $(addprefix $(RE_SRCSDIR), $(RE_SRCS:.c=.o))
 B_OBJS	= $(addprefix $(BUILTINS), $(B_SRCS:.c=.o))
 
 CC		= cc
-CFLAGS	= -g -I$(READLINEDIR)/include -Wall -Wextra -Werror #-fsanitize=address 
+CFLAGS	= -g -I$(READLINEDIR)/include #-Wall -Wextra -Werror #-fsanitize=address 
 RM		= rm -f
 READLINEDIR    := $(shell brew --prefix readline)
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ NAME	= minishell
 
 SRCSDIR	= src/
 
-SRCS = main.c free.c tokenize.c check_token.c parser.c redir_parser.c parser_utils.c lexer_parser_init.c expansion.c exp_init.c expand_parameter.c expand_utils.c signal.c #print.c
+SRCS = main.c free.c tokenize.c check_token.c parser.c redir_parser.c parser_utils.c lexer_parser_init.c expansion.c exp_init.c expand_parameter.c expand_utils.c signal.c print.c
 
 RE_SRCSDIR	= src_resaito/
 

--- a/inc/lexer_parser_utils.h
+++ b/inc/lexer_parser_utils.h
@@ -6,7 +6,7 @@
 /*   By: fwatanab <fwatanab@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/31 12:50:56 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/12/11 20:01:09 by fwatanab         ###   ########.fr       */
+/*   Updated: 2023/12/12 14:51:02 by fwatanab         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -46,5 +46,9 @@ char			*pop_token(t_token_list **list);
 char			**add_array(char **array, char *token);
 void			one_n_command(t_node *node);
 void			check_right_node(t_node *node);
+
+//print
+void			print_list(t_token_list *list);
+void			print_node(t_node *node);
 
 #endif

--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -6,7 +6,7 @@
 /*   By: resaito <resaito@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/18 21:17:45 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/12/12 16:31:38 by fwatanab         ###   ########.fr       */
+/*   Updated: 2023/12/12 16:52:21 by fwatanab         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,11 +18,11 @@
 # include "../libft/inc/libft_utils.h"
 # include "lexer_parser_utils.h"
 # include <fcntl.h>
+# include <stdio.h>
 # include <readline/history.h>
 # include <readline/readline.h>
 # include <signal.h>
 # include <stddef.h>
-# include <stdio.h>
 
 # define MINISHELL "minishell $ "
 # define SPACE ' '

--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -6,7 +6,7 @@
 /*   By: fwatanab <fwatanab@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/18 21:17:45 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/12/11 20:03:17 by fwatanab         ###   ########.fr       */
+/*   Updated: 2023/12/12 15:17:12 by fwatanab         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,7 +34,7 @@
 # define REDIR_HIRE "<<"
 # define REDIR_APPEND ">>"
 
-extern int	sig_status;
+extern int	g_sig_status;
 
 typedef struct s_token_list
 {
@@ -98,6 +98,7 @@ void			check_exp(t_node *node, t_envval *envval);
 //signal
 void			signal_handler(int sig);
 void			signal_fork_handler(int sig);
+void			signal_heredoc_handler(int sig);
 void			check_status(t_envval *envval);
 
 //free

--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -6,7 +6,7 @@
 /*   By: resaito <resaito@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/18 21:17:45 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/12/12 22:10:32 by fwatanab         ###   ########.fr       */
+/*   Updated: 2023/12/12 23:25:06 by fwatanab         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -110,6 +110,7 @@ void					redir_free(t_redir *redir);
 
 //error
 void					malloc_error(void);
+int						is_only_space(const char *str, t_envval *envval);
 
 //resaito search_path
 char					*search_path(const char *filename, t_env *env);

--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -6,7 +6,7 @@
 /*   By: resaito <resaito@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/18 21:17:45 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/12/12 16:52:21 by fwatanab         ###   ########.fr       */
+/*   Updated: 2023/12/12 22:00:12 by fwatanab         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -56,7 +56,7 @@ typedef enum e_type
 typedef struct s_redir
 {
 	enum e_type			type;
-	char				**file;
+	char				*file;
 	int					fd;
 	struct s_redir		*next;
 }						t_redir;

--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -6,7 +6,7 @@
 /*   By: resaito <resaito@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/18 21:17:45 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/12/12 22:00:12 by fwatanab         ###   ########.fr       */
+/*   Updated: 2023/12/12 22:03:34 by fwatanab         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -90,8 +90,7 @@ void					check_token(t_token_list *list);
 t_node					*parser_start(t_token_list **list, t_env *env);
 t_node					*parser(t_node *node, t_token_list **list,
 							t_parse_check *key, t_env *env);
-t_redir					*redir_parse(t_node *node, t_redir *redir,
-							t_token_list **list, char *token);
+t_redir					*redir_parse(t_redir *redir, t_token_list **list, char *token);
 
 //expansion
 void					check_exp(t_node *node, t_envval *envval);

--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -6,7 +6,7 @@
 /*   By: resaito <resaito@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/18 21:17:45 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/12/12 22:03:34 by fwatanab         ###   ########.fr       */
+/*   Updated: 2023/12/12 22:10:32 by fwatanab         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,7 +34,7 @@
 # define REDIR_HIRE "<<"
 # define REDIR_APPEND ">>"
 
-extern int				sig_status;
+extern int				g_sig_status;
 
 typedef struct s_token_list
 {
@@ -90,7 +90,8 @@ void					check_token(t_token_list *list);
 t_node					*parser_start(t_token_list **list, t_env *env);
 t_node					*parser(t_node *node, t_token_list **list,
 							t_parse_check *key, t_env *env);
-t_redir					*redir_parse(t_redir *redir, t_token_list **list, char *token);
+t_redir					*redir_parse(t_redir *redir, \
+						t_token_list **list, char *token);
 
 //expansion
 void					check_exp(t_node *node, t_envval *envval);

--- a/src/check_line.c
+++ b/src/check_line.c
@@ -1,0 +1,60 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   check_line.c                                       :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: fwatanab <fwatanab@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/12/12 23:15:40 by fwatanab          #+#    #+#             */
+/*   Updated: 2023/12/12 23:27:48 by fwatanab         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../inc/minishell.h"
+
+static void	type_count(const char *str, t_envval *envval)
+{
+	int	redir;
+	int	pype;
+
+	redir = 0;
+	pype = 0;
+	while (*str)
+	{
+		if (*str == '<' || *str == '>')
+			redir++;
+		else if (*str == '|')
+			pype++;
+		str++;
+	}
+	if (redir || pype)
+	{
+		printf("minishell: syntax error near unexpected token\n");
+		envval->status = 258;
+	}
+}
+
+int	is_only_space(const char *str, t_envval *envval)
+{
+	const char	*tmp;
+
+	tmp = str;
+	while (*tmp)
+	{
+		if (*tmp == ' ' || *tmp == '\t' || *tmp == '\n'
+			|| *tmp == '\v' || *tmp == '\f' || *tmp == '\r'
+			|| *tmp == '<' || *tmp == '>' || *tmp == '|')
+			;
+		else
+			return (1);
+		tmp++;
+	}
+	type_count(str, envval);
+	return (0);
+}
+
+void	malloc_error(void)
+{
+	printf("%s\n", "Failed to allocate memory");
+	exit(EXIT_FAILURE);
+}

--- a/src/free.c
+++ b/src/free.c
@@ -6,7 +6,7 @@
 /*   By: fwatanab <fwatanab@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/31 02:23:51 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/12/12 18:36:54 by fwatanab         ###   ########.fr       */
+/*   Updated: 2023/12/12 23:16:16 by fwatanab         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -76,10 +76,4 @@ void	node_free(t_node *node)
 	if (node->right)
 		node_free(node->right);
 	free(node);
-}
-
-void	malloc_error(void)
-{
-	printf("%s\n", "Failed to allocate memory");
-	exit(EXIT_FAILURE);
 }

--- a/src/free.c
+++ b/src/free.c
@@ -6,7 +6,7 @@
 /*   By: fwatanab <fwatanab@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/31 02:23:51 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/11/08 19:06:45 by fwatanab         ###   ########.fr       */
+/*   Updated: 2023/12/12 18:36:54 by fwatanab         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -55,7 +55,7 @@ void	redir_free(t_redir *redir)
 	{
 		tmp = redir;
 		if (redir->file)
-			str_array_free(tmp->file);
+			free(redir->file);
 		redir = redir->next;
 		free(tmp);
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: resaito <resaito@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/18 21:17:52 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/12/12 16:28:53 by fwatanab         ###   ########.fr       */
+/*   Updated: 2023/12/12 23:24:13 by fwatanab         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,20 +28,6 @@ void	minishell(char *line, t_envval *envval)
 	node_free(node);
 }
 
-static int	is_only_space(const char *str)
-{
-	while (*str)
-	{
-		if (*str == ' ' || *str == '\t' || *str == '\n'
-			|| *str == '\v' || *str == '\f' || *str == '\r')
-			;
-		else
-			return (1);
-		str++;
-	}
-	return (0);
-}
-
 void	bash_loop(t_envval *envval)
 {
 	char	*line;
@@ -59,7 +45,7 @@ void	bash_loop(t_envval *envval)
 			exit(envval->status);
 			break ;
 		}
-		else if (line[0] == '\0' || is_only_space(line) == 0)
+		else if (line[0] == '\0' || is_only_space(line, envval) == 0)
 			free(line);
 		else
 		{

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: fwatanab <fwatanab@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/18 21:17:52 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/12/12 11:11:11 by fwatanab         ###   ########.fr       */
+/*   Updated: 2023/12/12 14:39:26 by fwatanab         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,19 +28,19 @@ void	minishell(char *line, t_envval *envval)
 	node_free(node);
 }
 
-//static int	is_only_space(const char *str)
-//{
-//	while (*str)
-//	{
-//		if (*str == ' ' || *str == '\t' || *str == '\n'
-//				|| *str == '\v' || *str == '\f' || *str == '\r')
-//			;
-//		else
-//			return (1);
-//		str++;
-//	}
-//	return (0);
-//}
+static int	is_only_space(const char *str)
+{
+	while (*str)
+	{
+		if (*str == ' ' || *str == '\t' || *str == '\n'
+			|| *str == '\v' || *str == '\f' || *str == '\r')
+			;
+		else
+			return (1);
+		str++;
+	}
+	return (0);
+}
 
 void	bash_loop(t_envval *envval)
 {
@@ -59,7 +59,7 @@ void	bash_loop(t_envval *envval)
 			exit(envval->status);
 			break ;
 		}
-		else if (line[0] == '\0')// || is_only_space(line))
+		else if (line[0] == '\0' || is_only_space(line) == 0)
 			free(line);
 		else
 		{

--- a/src/parser.c
+++ b/src/parser.c
@@ -6,7 +6,7 @@
 /*   By: resaito <resaito@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/25 19:19:00 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/12/12 22:01:48 by fwatanab         ###   ########.fr       */
+/*   Updated: 2023/12/12 22:11:22 by fwatanab         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -63,9 +63,11 @@ static bool	redir_checker(t_node *node, t_parse_check *key, t_token_list **list)
 		|| ft_strcmp(key->token, "<<") == 0 || ft_strcmp(key->token, ">>") == 0)
 	{
 		if (key->key_type)
-			node->right->redir = redir_parse(node->right->redir, list, key->token);
+			node->right->redir = redir_parse(node->right->redir, \
+					list, key->token);
 		else if (!key->key_type)
-			node->left->redir = redir_parse(node->left->redir, list, key->token);
+			node->left->redir = redir_parse(node->left->redir, \
+					list, key->token);
 		return (true);
 	}
 	return (false);

--- a/src/parser.c
+++ b/src/parser.c
@@ -6,7 +6,7 @@
 /*   By: resaito <resaito@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/25 19:19:00 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/12/12 12:45:09 by resaito          ###   ########.fr       */
+/*   Updated: 2023/12/12 22:01:48 by fwatanab         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -63,11 +63,9 @@ static bool	redir_checker(t_node *node, t_parse_check *key, t_token_list **list)
 		|| ft_strcmp(key->token, "<<") == 0 || ft_strcmp(key->token, ">>") == 0)
 	{
 		if (key->key_type)
-			node->right->redir = redir_parse(\
-					node, node->right->redir, list, key->token);
+			node->right->redir = redir_parse(node->right->redir, list, key->token);
 		else if (!key->key_type)
-			node->left->redir = redir_parse(\
-					node, node->left->redir, list, key->token);
+			node->left->redir = redir_parse(node->left->redir, list, key->token);
 		return (true);
 	}
 	return (false);

--- a/src/print.c
+++ b/src/print.c
@@ -6,7 +6,7 @@
 /*   By: fwatanab <fwatanab@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/16 00:21:46 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/12/12 14:49:57 by fwatanab         ###   ########.fr       */
+/*   Updated: 2023/12/12 21:03:25 by fwatanab         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,18 +24,11 @@ void	print_list(t_token_list *list)
 
 static void	print_redir(t_redir *redir)
 {
-	size_t	i;
-
 	if (!redir)
 		return ;
 	printf("r_type: %u\n", redir->type);
 	printf("file:\n");
-	i = 0;
-	while (redir->file[i])
-	{
-		printf("     [%zu] %s\n", i, redir->file[i]);
-		i++;
-	}
+	printf("     %s\n", redir->file);
 	print_redir(redir->next);
 }
 

--- a/src/print.c
+++ b/src/print.c
@@ -6,77 +6,77 @@
 /*   By: fwatanab <fwatanab@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/16 00:21:46 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/12/11 19:23:13 by fwatanab         ###   ########.fr       */
+/*   Updated: 2023/12/12 14:49:57 by fwatanab         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../inc/minishell.h"
 
-//void	print_list(t_token_list *list)
-//{
-//	while (list)
-//	{
-//		printf("list-> %s\n", list->token);
-//		list = list->next;
-//	}
-//	printf("------------------\n\n");
-//}
-//
-//static void	print_redir(t_redir *redir)
-//{
-//	size_t	i;
-//
-//	if (!redir)
-//		return ;
-//	printf("r_type: %u\n", redir->type);
-//	printf("file:\n");
-//	i = 0;
-//	while (redir->file[i])
-//	{
-//		printf("     [%zu] %s\n", i, redir->file[i]);
-//		i++;
-//	}
-//	print_redir(redir->next);
-//}
-//
-//static void	printer(t_node *node)
-//{
-//	size_t	i;
-//
-//	if (node->name)
-//		printf("name: %s\n", node->name);
-//	printf("type: %u\n", node->type);
-//	if (node->args)
-//	{
-//		i = 0;
-//		printf("args:\n");
-//		while (node->args[i])
-//		{
-//			printf("	[%zu] %s\n",i , node->args[i]);
-//			i++;
-//		}
-//	}
-//}
-//
-//void	print_node(t_node *node)
-//{
-//	if (!node)
-//		return ;
-//	printer(node);
-//	if (node->redir)
-//	{
-//		printf("redir:\n");
-//		print_redir(node->redir);
-//	}
-//	printf("--------------\n");
-//	if (node->left)
-//	{
-//		printf("left\n");
-//		print_node(node->left);
-//	}
-//	if (node->right)
-//	{
-//		printf("right\n");
-//		print_node(node->right);
-//	}
-//}
+void	print_list(t_token_list *list)
+{
+	while (list)
+	{
+		printf("list-> %s\n", list->token);
+		list = list->next;
+	}
+	printf("------------------\n\n");
+}
+
+static void	print_redir(t_redir *redir)
+{
+	size_t	i;
+
+	if (!redir)
+		return ;
+	printf("r_type: %u\n", redir->type);
+	printf("file:\n");
+	i = 0;
+	while (redir->file[i])
+	{
+		printf("     [%zu] %s\n", i, redir->file[i]);
+		i++;
+	}
+	print_redir(redir->next);
+}
+
+static void	printer(t_node *node)
+{
+	size_t	i;
+
+	if (node->name)
+		printf("name: %s\n", node->name);
+	printf("type: %u\n", node->type);
+	if (node->args)
+	{
+		i = 0;
+		printf("args:\n");
+		while (node->args[i])
+		{
+			printf("     [%zu] %s\n", i, node->args[i]);
+			i++;
+		}
+	}
+}
+
+void	print_node(t_node *node)
+{
+	if (!node)
+		return ;
+	printer(node);
+	if (node->redir)
+	{
+		printf("redir:\n");
+		print_redir(node->redir);
+	}
+	printf("--------------\n");
+	if (node->left)
+	{
+		printf("left\n");
+		print_node(node->left);
+	}
+	if (node->right)
+	{
+		printf("right\n");
+		print_node(node->right);
+	}
+}

--- a/src/redir_parser.c
+++ b/src/redir_parser.c
@@ -6,7 +6,7 @@
 /*   By: fwatanab <fwatanab@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/08 19:48:34 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/12/12 22:01:07 by fwatanab         ###   ########.fr       */
+/*   Updated: 2023/12/12 22:11:52 by fwatanab         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,7 +14,8 @@
 
 static t_redir	*create_redir(void)
 {
-	t_redir		*new;
+	t_redir	*new;
+
 	new = (t_redir *)malloc(sizeof(t_redir));
 	if (!new)
 		return (NULL);

--- a/src/redir_parser.c
+++ b/src/redir_parser.c
@@ -6,7 +6,7 @@
 /*   By: fwatanab <fwatanab@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/08 19:48:34 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/12/12 21:56:46 by fwatanab         ###   ########.fr       */
+/*   Updated: 2023/12/12 22:01:07 by fwatanab         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -45,7 +45,7 @@ static void	add_redir_file(t_redir *redir, char *token)
 		return ;
 }
 
-t_redir	*redir_parse(t_node *node, t_redir *redir, \
+t_redir	*redir_parse(t_redir *redir, \
 		t_token_list **list, char *token)
 {
 	t_redir	*current;

--- a/src/redir_parser.c
+++ b/src/redir_parser.c
@@ -6,96 +6,25 @@
 /*   By: fwatanab <fwatanab@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/08 19:48:34 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/11/21 18:25:47 by fwatanab         ###   ########.fr       */
+/*   Updated: 2023/12/12 21:56:46 by fwatanab         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../inc/minishell.h"
 
-static size_t	redir_size(t_token_list **list, char *token)
-{
-	size_t			len;
-	t_token_list	*tmp;
-
-	tmp = *list;
-	len = 0;
-	if (tmp && (ft_strcmp(token, "<") == 0 || ft_strcmp(token, ">") == 0
-			|| ft_strcmp(token, "<<") == 0 || ft_strcmp(token, ">>") == 0))
-		token = pop_token(&tmp);
-	while (ft_strcmp(token, "|") != 0
-		&& ft_strcmp(token, "<") != 0 && ft_strcmp(token, ">") != 0
-		&& ft_strcmp(token, "<<") != 0 && ft_strcmp(token, ">>") != 0)
-	{
-		len++;
-		if (!tmp)
-			break ;
-		token = pop_token(&tmp);
-	}
-	return (len);
-}
-
-static t_redir	*create_redir(size_t len)
+static t_redir	*create_redir(void)
 {
 	t_redir		*new;
-	size_t		i;
-
-	if (!len)
-		return (NULL);
 	new = (t_redir *)malloc(sizeof(t_redir));
 	if (!new)
 		return (NULL);
-	new->file = (char **)malloc(sizeof(char *) * (len + 1));
-	if (!new->file)
-	{
-		free(new);
-		return (NULL);
-	}
-	i = 0;
-	while (i <= len)
-		new->file[i++] = NULL;
+	new->file = NULL;
 	new->next = NULL;
 	return (new);
 }
 
-static char	*add_redir_file(t_node *node, t_redir *redir, t_token_list **list)
+static void	set_redir_type(t_redir *redir, char *token)
 {
-	char	*token;
-	size_t	i;
-
-	if (*list)
-		token = pop_token(list);
-	i = 0;
-	while (ft_strcmp(token, "<") != 0 && ft_strcmp(token, ">") != 0
-		&& ft_strcmp(token, "<<") != 0 && ft_strcmp(token, ">>") != 0)
-	{
-		redir->file[i] = ft_strdup(token);
-		if (!redir->file[i])
-		{
-			list_free(list);
-			node_free(node);
-			malloc_error();
-		}
-		if (!*list || ft_strcmp((*list)->token, "|") == 0)
-			break ;
-		token = pop_token(list);
-		i++;
-	}
-	return (token);
-}
-
-t_redir	*redir_parse(t_node *node, t_redir *redir, \
-		t_token_list **list, char *token)
-{
-	if (!list || (ft_strcmp(token, "<") != 0 && ft_strcmp(token, ">") != 0
-			&& ft_strcmp(token, "<<") != 0 && ft_strcmp(token, ">>") != 0))
-		return (NULL);
-	redir = create_redir(redir_size(list, token));
-	if (!redir)
-	{
-		list_free(list);
-		node_free(node);
-		malloc_error();
-	}
 	if (ft_strcmp(token, "<") == 0)
 		redir->type = N_REDIR_IN;
 	else if (ft_strcmp(token, ">") == 0)
@@ -104,9 +33,43 @@ t_redir	*redir_parse(t_node *node, t_redir *redir, \
 		redir->type = N_REDIR_HERE;
 	else if (ft_strcmp(token, ">>") == 0)
 		redir->type = N_REDIR_APPEND;
-	token = add_redir_file(node, redir, list);
-	if (*list && (ft_strcmp(token, "<") == 0 || ft_strcmp(token, ">") == 0
+}
+
+static void	add_redir_file(t_redir *redir, char *token)
+{
+	if (!token && (ft_strcmp(token, "<") == 0 || ft_strcmp(token, ">") == 0
 			|| ft_strcmp(token, "<<") == 0 || ft_strcmp(token, ">>") == 0))
-		redir->next = redir_parse(node, redir->next, list, token);
+		return ;
+	redir->file = ft_strdup(token);
+	if (!redir->file)
+		return ;
+}
+
+t_redir	*redir_parse(t_node *node, t_redir *redir, \
+		t_token_list **list, char *token)
+{
+	t_redir	*current;
+
+	if (!list || (ft_strcmp(token, "<") != 0 && ft_strcmp(token, ">") != 0
+			&& ft_strcmp(token, "<<") != 0 && ft_strcmp(token, ">>") != 0))
+		return (NULL);
+	if (!redir)
+	{
+		redir = create_redir();
+		current = redir;
+	}
+	else
+	{
+		redir->next = create_redir();
+		current = redir->next;
+	}
+	if (!redir)
+	{
+		printf("minishell: syntax error near unexpected token `newline'\n");
+		return (NULL);
+	}
+	set_redir_type(current, token);
+	token = pop_token(list);
+	add_redir_file(current, token);
 	return (redir);
 }

--- a/src/signal.c
+++ b/src/signal.c
@@ -6,13 +6,13 @@
 /*   By: fwatanab <fwatanab@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/25 18:26:49 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/12/11 16:58:29 by fwatanab         ###   ########.fr       */
+/*   Updated: 2023/12/12 16:06:34 by fwatanab         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../inc/minishell.h"
 
-int	sig_status = 0;
+int	g_sig_status = 0;
 
 void	signal_handler(int sig)
 {
@@ -22,7 +22,7 @@ void	signal_handler(int sig)
 		rl_on_new_line();
 		rl_replace_line("", 0);
 		rl_redisplay();
-		sig_status = 1;
+		g_sig_status = 1;
 	}
 	else if (sig == SIGQUIT)
 		;
@@ -39,14 +39,25 @@ void	signal_fork_handler(int sig)
 		write(1, "\n", 1);
 	}
 	if (sig)
-		sig_status = 128 + sig;
+		g_sig_status = 128 + sig;
+}
+
+void	signal_heredoc_handler(int sig)
+{
+	if (sig == SIGINT)
+	{
+		write(1, "\n", 1);
+		g_sig_status = 1;
+	}
+	else if (sig == SIGQUIT)
+		;
 }
 
 void	check_status(t_envval *envval)
 {
-	if (sig_status)
+	if (g_sig_status)
 	{
-		envval->status = sig_status;
-		sig_status = 0;
+		envval->status = g_sig_status;
+		g_sig_status = 0;
 	}
 }


### PR DESCRIPTION
**リダイレクト修正後の挙動**
```
minishell $ cat Makefile > a.txt b.txt > c.txt
name: /bin/cat
type: 1
args:
     [0] cat
     [1] Makefile
     [2] b.txt
redir:
r_type: 3
file:
     a.txt
r_type: 3
file:
     c.txt
--------------
left
type: 0
--------------
right
type: 0
--------------
minishell $ echo hi < ./test_files/infile bye bye
name: /bin/echo
type: 1
args:
     [0] echo
     [1] hi
     [2] bye
     [3] bye
redir:
r_type: 2
file:
     ./test_files/infile
--------------
left
type: 0
--------------
right
type: 0
--------------
minishell $
```

char **fileからchar *fileに変えたことにより実行の方も変更が必要なので対応お願いします
```
typedef struct s_redir
{
	enum e_type			type;
	char				*file;
	int					fd;
	struct s_redir		*next;
}						t_redir;
```

今回main関数のft_execution(node, envval);をコメントアウトして実行しました