### PR TITLE
redirectのファイルの権限を確認するように変更

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,9 @@ RE_SRCS = exec.c \
 			execution_by_process.c \
 			print_error.c \
 			is_single_command.c \
-			get_exit_code.c
+			get_exit_code.c \
+			output_redir.c \
+			ft_stat.c
 
 BUILTINS	= builtins/
 

--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -23,6 +23,7 @@
 # include <readline/readline.h>
 # include <signal.h>
 # include <stddef.h>
+# include <stdbool.h>
 
 # define MINISHELL "minishell $ "
 # define SPACE ' '
@@ -128,11 +129,15 @@ int						redir_dup(t_node *node);
 int						indirect_exec(t_node *node);
 int						heredoc_exec(t_redir *redir, t_envval *envval);
 int						input_redir(t_node *node, t_envval *envval);
+int						output_redir(t_node *node, t_envval *envval);
+bool					is_type_redirect(t_redir *redir);
+bool					is_type_append(t_redir *redir);
 bool					is_type_heredoc(t_redir *redir);
 bool					is_type_indirect(t_redir *redir);
 int						dup_2_stdin(t_node *node);
-int						able_file(char *filepath, t_redir *redir);
+int						dup_2_stdout(t_node *node);
 bool    				able_read(char *filepath);
+bool    				able_write(char *filepath);
 
 // env
 t_env					*new_envs(char **envp);

--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -131,6 +131,8 @@ int						input_redir(t_node *node, t_envval *envval);
 bool					is_type_heredoc(t_redir *redir);
 bool					is_type_indirect(t_redir *redir);
 int						dup_2_stdin(t_node *node);
+int						able_file(char *filepath, t_redir *redir);
+bool    				able_read(char *filepath);
 
 // env
 t_env					*new_envs(char **envp);

--- a/src_resaito/exec.c
+++ b/src_resaito/exec.c
@@ -50,6 +50,8 @@ void	execution(t_node *node, bool is_exec_pipe, t_envval *envval)
 	if (node->type == N_COMMAND)
 	{
 		status = dup_2_stdin(node);
+		if (status == 0)
+			status = dup_2_stdout(node);
 		if (status != 0)
 		{
 			envval->status = status;
@@ -82,9 +84,12 @@ void	wait_all(t_node *node, t_envval *envval)
 void	ft_execution(t_node *node, t_envval *envval)
 {
 	int	dupin;
+	int dupout;
 
 	dupin = dup(STDIN_FILENO);
+	dupout = dup(STDOUT_FILENO);
 	input_redir(node, envval);
+	output_redir(node, envval);
 	if (is_single_command(node) && is_builtin(node))
 		exec_builtin(node, envval);
 	else
@@ -94,6 +99,8 @@ void	ft_execution(t_node *node, t_envval *envval)
 	}
 	dup2(dupin, STDIN_FILENO);
 	close(dupin);
+	dup2(dupout, STDOUT_FILENO);
+	close(dupout);
 }
 
 // bool	has_pipe(t_node *node)

--- a/src_resaito/execution_by_process.c
+++ b/src_resaito/execution_by_process.c
@@ -24,7 +24,6 @@ int	child_process(t_node *node, bool has_pipe, t_envval *envval, int pipefd[2])
 		dup2(pipefd[1], STDOUT_FILENO);
 		close(pipefd[1]);
 	}
-	redir_dup(node);
 	if (!node->name && ft_getpath(envval->env))
 		exit(print_error(node->args[0], "command not found", 127));
 	else if (!ft_getpath(envval->env))

--- a/src_resaito/ft_stat.c
+++ b/src_resaito/ft_stat.c
@@ -1,0 +1,52 @@
+#include "../inc/minishell.h"
+#include <time.h>
+#include <sys/stat.h>
+#include <stdbool.h>
+
+bool    able_read(char *filepath)
+{
+    struct stat buf;
+    
+    if (stat(filepath, &buf) < 0)
+        exit(1);
+    if (buf.st_mode & S_IRUSR)
+    {
+        printf("read true\n");
+        return (true);
+    }
+    printf("read false\n");
+    return (false);
+}
+
+bool    able_write(char *filepath)
+{
+    struct stat buf;
+    
+    if (stat(filepath, &buf) < 0)
+        exit(1);
+    if (buf.st_mode & S_IWUSR)
+    {
+        printf("write true\n");
+        return (true);
+    }
+    printf("write false\n");
+    return (false);
+}
+
+int    able_file(char *filepath, t_redir *redir)
+{
+    t_redir *tmp;
+
+    if (!redir)
+        return(0);
+    tmp = redir;
+    while (tmp)
+    {
+        if ((tmp->type == N_REDIR_IN && !able_read(filepath)) ||
+            ((tmp->type == N_REDIR_OUT || tmp->type == N_REDIR_APPEND)
+            && !able_write(filepath)))
+            return(print_error(tmp->file, "Permission denied", 1));
+        tmp = tmp->next;
+    }
+    return (0);
+}

--- a/src_resaito/ft_stat.c
+++ b/src_resaito/ft_stat.c
@@ -10,11 +10,7 @@ bool    able_read(char *filepath)
     if (stat(filepath, &buf) < 0)
         exit(1);
     if (buf.st_mode & S_IRUSR)
-    {
-        printf("read true\n");
         return (true);
-    }
-    printf("read false\n");
     return (false);
 }
 
@@ -25,28 +21,6 @@ bool    able_write(char *filepath)
     if (stat(filepath, &buf) < 0)
         exit(1);
     if (buf.st_mode & S_IWUSR)
-    {
-        printf("write true\n");
         return (true);
-    }
-    printf("write false\n");
     return (false);
-}
-
-int    able_file(char *filepath, t_redir *redir)
-{
-    t_redir *tmp;
-
-    if (!redir)
-        return(0);
-    tmp = redir;
-    while (tmp)
-    {
-        if ((tmp->type == N_REDIR_IN && !able_read(filepath)) ||
-            ((tmp->type == N_REDIR_OUT || tmp->type == N_REDIR_APPEND)
-            && !able_write(filepath)))
-            return(print_error(tmp->file, "Permission denied", 1));
-        tmp = tmp->next;
-    }
-    return (0);
 }

--- a/src_resaito/get_exit_code.c
+++ b/src_resaito/get_exit_code.c
@@ -14,6 +14,8 @@
 
 int	get_exit_code(int n)
 {
+	if (n == 1)
+		return (n);
 	if (n % 256 == 0)
 		return (n / 256);
 	else

--- a/src_resaito/input_redir.c
+++ b/src_resaito/input_redir.c
@@ -51,6 +51,8 @@ int	dup_2_stdin(t_node *node)
 	{
 		if (is_type_heredoc(redir) || is_type_indirect(redir))
 		{
+			if (!able_read(redir->file))
+				return (print_error(redir->file, "Permission denied", 1));
 			if (redir->fd == -1)
 				return (print_error(redir->file, "No such file or directory",
 						1));

--- a/src_resaito/output_redir.c
+++ b/src_resaito/output_redir.c
@@ -1,0 +1,69 @@
+#include "../inc/minishell.h"
+#include <errno.h>
+#include <string.h>
+
+int	output_redir(t_node *node, t_envval *envval)
+{
+	t_redir	*redir;
+
+	if (node->type == NONE)
+		return (0);
+	if (node->type == N_PIPE)
+	{
+		output_redir(node->left, envval);
+		output_redir(node->right, envval);
+	}
+	if (node->type == N_COMMAND)
+	{
+		redir = node->redir;
+		while (redir != NULL)
+		{
+			if (is_type_redirect(redir))
+				redir->fd = open(redir->file, O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC,
+					S_IRUSR | S_IWUSR);
+			if (is_type_append(redir))
+				redir->fd = open(redir->file, O_WRONLY | O_CREAT | O_APPEND | O_CLOEXEC,
+					S_IRUSR | S_IWUSR);
+			redir = redir->next;
+		}
+	}
+	return (0);
+}
+
+int	dup_2_stdout(t_node *node)
+{
+	t_redir	*redir;
+
+	if (node->redir == NULL)
+		return (0);
+	redir = node->redir;
+	while (redir != NULL)
+	{
+		if (is_type_redirect(redir) || is_type_append(redir))
+		{
+            if (!able_write(redir->file))
+                return (print_error(redir->file, "Permission denied", 1));
+			if (redir->fd == -1)
+				return (print_error(redir->file, "No such file or directory",
+						1));
+			dup2(redir->fd, STDOUT_FILENO);
+			close(redir->fd);
+		}
+		redir = redir->next;
+	}
+	return (0);
+}
+
+bool is_type_redirect(t_redir *redir)
+{
+	if (redir != NULL && redir->type == N_REDIR_OUT)
+		return (true);
+	return (false);
+}
+
+bool	is_type_append(t_redir *redir)
+{
+	if (redir != NULL && redir->type == N_REDIR_APPEND)
+		return (true);
+	return (false);
+}


### PR DESCRIPTION
## やったこと
redirectのファイルにPermission deniedの実装
```
minishell $ ls -l | grep test.txt 
----rwxrwx   1 saitoureina  staff     80 12 14 14:26 test.txt
```
test.txtに権限がない時
```
minishell $ ls > test.txt
minishell: test.txt: Permission denied
minishell $ ls >> test.txt
minishell: test.txt: Permission denied
minishell $ cat < test.txt 
minishell: test.txt: Permission denied
minishell $ echo $?
1
minishell $
```