### PR TITLE
heredoc終わったらminishell終了しちゃう問題

### DIFF
--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -123,6 +123,7 @@ void					ft_execution(t_node *node, t_envval *envval);
 int						child_process(t_node *node, bool has_pipe,
 							t_envval *envval, int pipefd[2]);
 void					parent_process(bool has_pipe, int pipefd[2]);
+bool    				able_exec(char *filepath);
 
 // redir
 int						redir_dup(t_node *node);

--- a/src_resaito/ft_stat.c
+++ b/src_resaito/ft_stat.c
@@ -24,3 +24,14 @@ bool    able_write(char *filepath)
         return (true);
     return (false);
 }
+
+bool    able_exec(char *filepath)
+{
+    struct stat buf;
+    
+    if (stat(filepath, &buf) < 0)
+        exit(1);
+    if (buf.st_mode & S_IXUSR)
+        return (true);
+    return (false);
+}

--- a/src_resaito/ft_stat.c
+++ b/src_resaito/ft_stat.c
@@ -8,7 +8,7 @@ bool    able_read(char *filepath)
     struct stat buf;
     
     if (stat(filepath, &buf) < 0)
-        exit(1);
+        return (true);
     if (buf.st_mode & S_IRUSR)
         return (true);
     return (false);
@@ -19,7 +19,7 @@ bool    able_write(char *filepath)
     struct stat buf;
     
     if (stat(filepath, &buf) < 0)
-        exit(1);
+        return (true);
     if (buf.st_mode & S_IWUSR)
         return (true);
     return (false);


### PR DESCRIPTION
## やったこと
子プロセスではないところでexitしていたのでreturnに変更
```
minishell $ cat << hoge
> aaa
> hoge
ここでminishell終了
```
変更後
```
minishell $ cat << hoge
> aaa
> hoge
aaa
minishell $
```