### PR TITLE
閉じられていないクォート、ブレースの際の挙動修正

### DIFF
--- a/inc/expansion.h
+++ b/inc/expansion.h
@@ -6,7 +6,7 @@
 /*   By: fwatanab <fwatanab@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/12 03:53:40 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/12/14 20:04:02 by fwatanab         ###   ########.fr       */
+/*   Updated: 2023/12/16 14:28:49 by fwatanab         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -36,7 +36,7 @@ typedef struct s_quote_status
 //init
 t_parm			*parameter_init(char *token);
 
-char			*check_command(char *str);
+char			*check_command(char *str, t_node *node, t_envval *envval);
 char			*expand_parameter(char *token, t_envval *envval);
 char			*check_parameter(t_parm *parm, t_envval *envval);
 int				check_question(t_parm *parm, t_envval *envval);

--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -6,7 +6,7 @@
 /*   By: resaito <resaito@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/18 21:17:45 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/12/13 19:09:24 by fwatanab         ###   ########.fr       */
+/*   Updated: 2023/12/16 19:39:06 by fwatanab         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -95,7 +95,7 @@ t_redir					*redir_parse(t_redir *redir, \
 						t_token_list **list, char *token);
 
 //expansion
-void					check_exp(t_node *node, t_envval *envval);
+int						check_exp(t_node *node, t_envval *envval);
 
 //signal
 void					signal_handler(int sig);
@@ -123,7 +123,7 @@ void					ft_execution(t_node *node, t_envval *envval);
 int						child_process(t_node *node, bool has_pipe,
 							t_envval *envval, int pipefd[2]);
 void					parent_process(bool has_pipe, int pipefd[2]);
-bool    				able_exec(char *filepath);
+bool					able_exec(char *filepath);
 
 // redir
 int						redir_dup(t_node *node);
@@ -137,8 +137,8 @@ bool					is_type_heredoc(t_redir *redir);
 bool					is_type_indirect(t_redir *redir);
 int						dup_2_stdin(t_node *node);
 int						dup_2_stdout(t_node *node);
-bool    				able_read(char *filepath);
-bool    				able_write(char *filepath);
+bool					able_read(char *filepath);
+bool					able_write(char *filepath);
 
 // env
 t_env					*new_envs(char **envp);

--- a/src/check_command.c
+++ b/src/check_command.c
@@ -6,7 +6,7 @@
 /*   By: fwatanab <fwatanab@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/13 18:47:48 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/12/14 20:03:21 by fwatanab         ###   ########.fr       */
+/*   Updated: 2023/12/16 19:34:32 by fwatanab         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -60,14 +60,43 @@ static char	*check_env_var_braces(char *str)
 	return (NULL);
 }
 
-char	*check_command(char *str)
+static void	delete_node(t_node *node, t_envval *envval)
+{
+	size_t	i;
+
+	if (!node)
+		return ;
+	i = 0;
+	if (node->args)
+	{
+		while (node->args[i])
+		{
+			node->args[i][0] = '\0';
+			i++;
+		}
+	}
+	if (node->redir)
+		node->redir->file[0] = '\0';
+	if (node->left)
+		delete_node(node->left, envval);
+	if (node->right)
+		delete_node(node->right, envval);
+}
+
+char	*check_command(char *str, t_node *node, t_envval *envval)
 {
 	char	*result;
 	char	*token;
 
 	result = check_close_quote(str);
 	token = check_env_var_braces(str);
-	if (result || token)
-		str[0] = '\0';
+	if (token || result)
+	{
+		if (result)
+			printf("minishell: Unclosed quote found: %s\n", result);
+		if (token)
+			printf("minishell: Unclosed brace found: %s\n", token);
+		delete_node(node, envval);
+	}
 	return (str);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: resaito <resaito@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/18 21:17:52 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/12/15 18:56:25 by fwatanab         ###   ########.fr       */
+/*   Updated: 2023/12/16 19:42:55 by fwatanab         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,7 +22,8 @@ void	minishell(char *line, t_envval *envval)
 	tmp = list;
 	check_token(list);
 	node = parser_start(&list);
-	check_exp(node, envval);
+	if (check_exp(node, envval) == 1)
+		return ;
 	list_free(&tmp);
 	ft_execution(node, envval);
 	node_free(node);

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: resaito <resaito@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/18 21:17:52 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/12/16 19:42:55 by fwatanab         ###   ########.fr       */
+/*   Updated: 2023/12/16 19:50:23 by fwatanab         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,9 +22,9 @@ void	minishell(char *line, t_envval *envval)
 	tmp = list;
 	check_token(list);
 	node = parser_start(&list);
+	list_free(&tmp);
 	if (check_exp(node, envval) == 1)
 		return ;
-	list_free(&tmp);
 	ft_execution(node, envval);
 	node_free(node);
 }

--- a/src/signal.c
+++ b/src/signal.c
@@ -6,7 +6,7 @@
 /*   By: fwatanab <fwatanab@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/25 18:26:49 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/12/15 18:56:42 by fwatanab         ###   ########.fr       */
+/*   Updated: 2023/12/16 19:39:28 by fwatanab         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -64,5 +64,4 @@ int	signal_check(void)
 	if (g_sig_status)
 		rl_done = 1;
 	return (0);
-
 }


### PR DESCRIPTION
閉じられていないクォートの時の挙動が統一されていなかったため修正しました
エラー扱いとして終了ステータスに１を返すようにしました
具体的には閉じられていないクォート、ブレースの時にはexecに行く前にnodeを完全にfreeしてreturnしてます

課題的には自由にしていいところだと思うので自己満の挙動になってます

**修正前の挙動**
```
minihsell $ echo "aa

minihsell $ echo aa "test
aa
minihsell $ echo $?
0
minihsell $
```

**修正後の挙動**
```
minishell $ echo aa "test
minishell: Unclosed quote found: "
minishell $ echo $?
1
minishell $ echo aa 'test
minishell: Unclosed quote found: '
minishell $ echo $?
1
minishell $ echo aa ${HOME
minishell: Unclosed brace found: }
minishell $ echo $?
1
minihsell $
```