### PR TITLE
issueの対応と細かい修正

### DIFF
--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -70,6 +70,7 @@ typedef struct s_node
 	struct s_redir		*redir;
 	struct s_node		*left;
 	struct s_node		*right;
+	pid_t				pid;
 }						t_node;
 
 typedef struct s_env

--- a/src/lexer_parser_init.c
+++ b/src/lexer_parser_init.c
@@ -38,6 +38,7 @@ t_node	*node_init(void)
 	node->redir = NULL;
 	node->left = NULL;
 	node->right = NULL;
+	node->pid = 0;
 	return (node);
 }
 

--- a/src/signal.c
+++ b/src/signal.c
@@ -52,11 +52,9 @@ void	signal_heredoc_handler(int sig)
 
 void	check_status(t_envval *envval)
 {
-	if (g_sig_status)
-	{
+	if (g_sig_status && envval->status != 0)
 		envval->status = g_sig_status;
-		g_sig_status = 0;
-	}
+	g_sig_status = 0;
 }
 
 int	signal_check(void)

--- a/src_resaito/exec.c
+++ b/src_resaito/exec.c
@@ -76,7 +76,6 @@ void	wait_all(t_node *node, t_envval *envval)
 	}
 	if (node->type == N_COMMAND)
 	{
-		printf("pid: %d\n", node->pid);
 		waitpid(node->pid, &status, 0);
 		envval->status = get_exit_code(status);
 	}
@@ -98,6 +97,8 @@ void	ft_execution(t_node *node, t_envval *envval)
 	else
 	{
 		execution(node, false, envval);
+		close(STDIN_FILENO);
+		close(STDOUT_FILENO);
 		wait_all(node, envval);
 	}
 	dup2(dupin, STDIN_FILENO);

--- a/src_resaito/exec.c
+++ b/src_resaito/exec.c
@@ -21,6 +21,7 @@ int	execute_command(t_node *node, bool has_pipe, t_envval *envval)
 	if (has_pipe)
 		ft_pipe(pipefd);
 	pid = fork();
+	node->pid = pid;
 	if (pid < 0)
 		ft_perror("fork");
 	else if (pid == 0)
@@ -75,7 +76,8 @@ void	wait_all(t_node *node, t_envval *envval)
 	}
 	if (node->type == N_COMMAND)
 	{
-		wait(&status);
+		printf("pid: %d\n", node->pid);
+		waitpid(node->pid, &status, 0);
 		envval->status = get_exit_code(status);
 	}
 	return ;

--- a/src_resaito/exec.c
+++ b/src_resaito/exec.c
@@ -88,7 +88,8 @@ void	ft_execution(t_node *node, t_envval *envval)
 
 	dupin = dup(STDIN_FILENO);
 	dupout = dup(STDOUT_FILENO);
-	input_redir(node, envval);
+	if (input_redir(node, envval) == -1)
+		return ;
 	output_redir(node, envval);
 	if (is_single_command(node) && is_builtin(node))
 		exec_builtin(node, envval);

--- a/src_resaito/exec.c
+++ b/src_resaito/exec.c
@@ -100,6 +100,7 @@ void	ft_execution(t_node *node, t_envval *envval)
 		close(STDIN_FILENO);
 		close(STDOUT_FILENO);
 		wait_all(node, envval);
+
 	}
 	dup2(dupin, STDIN_FILENO);
 	close(dupin);

--- a/src_resaito/input_redir.c
+++ b/src_resaito/input_redir.c
@@ -56,6 +56,8 @@ int	dup_2_stdin(t_node *node)
 			if (redir->fd == -1)
 				return (print_error(redir->file, "No such file or directory",
 						1));
+			if (redir->fd == -2)
+				return (1);
 			dup2(redir->fd, STDIN_FILENO);
 			close(redir->fd);
 		}

--- a/src_resaito/redirect_dup.c
+++ b/src_resaito/redirect_dup.c
@@ -46,6 +46,8 @@ int	heredoc_exec(t_redir *redir, t_envval *envval)
 	char	*line;
 	int		pipefd[2];
 
+	if (g_sig_status == 1)
+		return (-2);
 	if (pipe(pipefd) < 0)
 	{
 		perror("pipe");
@@ -62,7 +64,8 @@ int	heredoc_exec(t_redir *redir, t_envval *envval)
 			if (g_sig_status == 1)
 				free(line);
 			close(pipefd[1]);
-			break ;
+			close(pipefd[0]);
+			return (-2);
 		}
 		if (ft_strncmp(line, redir->file, ft_strlen(redir->file)) == 0)
 		{

--- a/src_resaito/redirect_dup.c
+++ b/src_resaito/redirect_dup.c
@@ -59,7 +59,7 @@ int	heredoc_exec(t_redir *redir, t_envval *envval)
 		signal(SIGQUIT, signal_heredoc_handler);
 		rl_event_hook = signal_check;
 		line = readline("> ");
-		if (line == NULL || g_sig_status == 1)
+		if ( g_sig_status == 1)
 		{
 			if (g_sig_status == 1)
 				free(line);
@@ -67,7 +67,7 @@ int	heredoc_exec(t_redir *redir, t_envval *envval)
 			close(pipefd[0]);
 			return (-2);
 		}
-		if (ft_strncmp(line, redir->file, ft_strlen(redir->file)) == 0)
+		if (line == NULL || ft_strncmp(line, redir->file, ft_strlen(redir->file)) == 0)
 		{
 			free(line);
 			close(pipefd[1]);


### PR DESCRIPTION
## やったこと
heredoc中のcntl + c, cntl + dの挙動をbashに合わせた
```
minishell $ cat << hoge
> aaa
> bbb
>  <-ここでcntl c
minishell $ 
```
```
minishell $ cat << hoge
> aaa
>  <-ここでcntl d
aaa
minishell $
```
wait()からwaitpid()に変更
　nodeの構造体にpid_tを追加
サイズが大きいファイルを読み込んでパイプする時に終了せず入力待ちになるのを修正
cat | lsの時の終了ステータスが書き換わる問題を修正
```
minishell $ cat | ls
Makefile                libft                   src
builtins                minishell               src_resaito
inc                     minishell_tester        test.txt
^Cminishell $ echo $?
0
minishell $
```
