### PR TITLE
signal挙動修正 / cat | ls の挙動修正が必要

### DIFF
--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -6,7 +6,7 @@
 /*   By: resaito <resaito@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/18 21:17:45 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/12/16 19:39:06 by fwatanab         ###   ########.fr       */
+/*   Updated: 2023/12/18 18:32:25 by fwatanab         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -103,6 +103,7 @@ void					signal_handler(int sig);
 void					signal_fork_handler(int sig);
 void					signal_heredoc_handler(int sig);
 void					check_status(t_envval *envval);
+void					check_fork_status(t_envval *envval);
 
 //free
 void					list_free(t_token_list **list);

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: resaito <resaito@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/18 21:17:52 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/12/17 19:17:36 by fwatanab         ###   ########.fr       */
+/*   Updated: 2023/12/18 18:32:44 by fwatanab         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,13 +38,9 @@ void	bash_loop(t_envval *envval)
 	{
 		signal(SIGINT, signal_handler);
 		signal(SIGQUIT, signal_handler);
-		check_status(envval);
+		check_fork_status(envval);
 		line = readline(MINISHELL);
-		if (g_sig_status)
-		{
-			envval->status = 1;
-			g_sig_status = 0;
-		}
+		check_status(envval);
 		if (!line)
 		{
 			write(1, "exit\n", 5);

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: resaito <resaito@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/18 21:17:52 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/12/18 18:32:44 by fwatanab         ###   ########.fr       */
+/*   Updated: 2023/12/18 18:44:18 by fwatanab         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,14 +47,12 @@ void	bash_loop(t_envval *envval)
 			exit(envval->status);
 			break ;
 		}
-		else if (line[0] == '\0' || is_only_space(line, envval) == 0)
-			free(line);
-		else
+		else if (!(line[0] == '\0' || is_only_space(line, envval) == 0))
 		{
 			add_history(line);
 			minishell(line, envval);
-			free(line);
 		}
+		free(line);
 	}
 	rl_clear_history();
 }

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: resaito <resaito@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/18 21:17:52 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/12/16 19:50:23 by fwatanab         ###   ########.fr       */
+/*   Updated: 2023/12/17 19:17:36 by fwatanab         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -40,6 +40,11 @@ void	bash_loop(t_envval *envval)
 		signal(SIGQUIT, signal_handler);
 		check_status(envval);
 		line = readline(MINISHELL);
+		if (g_sig_status)
+		{
+			envval->status = 1;
+			g_sig_status = 0;
+		}
 		if (!line)
 		{
 			write(1, "exit\n", 5);

--- a/src/signal.c
+++ b/src/signal.c
@@ -6,7 +6,7 @@
 /*   By: fwatanab <fwatanab@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/25 18:26:49 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/12/16 19:39:28 by fwatanab         ###   ########.fr       */
+/*   Updated: 2023/12/18 18:33:23 by fwatanab         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -52,14 +52,14 @@ void	signal_heredoc_handler(int sig)
 
 void	check_status(t_envval *envval)
 {
-	if (g_sig_status && envval->status != 0)
-		envval->status = g_sig_status;
+	if (g_sig_status)
+		envval->status = 1;
 	g_sig_status = 0;
 }
 
-int	signal_check(void)
+void	check_fork_status(t_envval *envval)
 {
-	if (g_sig_status)
-		rl_done = 1;
-	return (0);
+	if (g_sig_status && envval->status != 0)
+		envval->status = g_sig_status;
+	g_sig_status = 0;
 }

--- a/src_resaito/exec.c
+++ b/src_resaito/exec.c
@@ -6,7 +6,7 @@
 /*   By: fwatanab <fwatanab@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/30 13:39:58 by resaito           #+#    #+#             */
-/*   Updated: 2023/12/11 18:00:51 by fwatanab         ###   ########.fr       */
+/*   Updated: 2023/12/17 19:57:11 by fwatanab         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,6 +17,7 @@ int	execute_command(t_node *node, bool has_pipe, t_envval *envval)
 {
 	int		pipefd[2];
 	pid_t	pid;
+	int		status;
 
 	if (has_pipe)
 		ft_pipe(pipefd);
@@ -30,6 +31,7 @@ int	execute_command(t_node *node, bool has_pipe, t_envval *envval)
 	{
 		signal(SIGINT, signal_fork_handler);
 		signal(SIGQUIT, signal_fork_handler);
+		waitpid(pid, &status, 0);
 		parent_process(has_pipe, pipefd);
 		return (0);
 	}

--- a/src_resaito/redirect_dup.c
+++ b/src_resaito/redirect_dup.c
@@ -6,7 +6,7 @@
 /*   By: resaito <resaito@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/09 14:05:49 by resaito           #+#    #+#             */
-/*   Updated: 2023/12/15 18:57:19 by fwatanab         ###   ########.fr       */
+/*   Updated: 2023/12/18 18:29:41 by fwatanab         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,7 +14,6 @@
 #include "../inc/expansion.h"
 
 char	*expand_parameter(char *token, t_envval *envval);
-int		signal_check(void);
 
 int	redir_dup(t_node *node)
 {
@@ -38,6 +37,13 @@ int	redir_dup(t_node *node)
 	}
 	dup2(out_fd, STDOUT_FILENO);
 	close(out_fd);
+	return (0);
+}
+
+int	signal_check(void)
+{
+	if (g_sig_status)
+		rl_done = 1;
 	return (0);
 }
 


### PR DESCRIPTION
`main.cの43行目のif文でcheck_statusの代わりを行うことで通常時のシグナルの終了ステータスを正しく取っている`
```
if (g_sig_status)
{
	envval->status = 1;
	g_sig_status = 0;
}
```
**src_resait_exec.cにてwaitpidを使うことでシグナルを反映させることができたが、cat | ls の時の挙動がおかしくなる**
元々はwaitpidを使わなくてもいけていたが、merge後にバグってしまった(元々不安定だった可能性あり)
```
minishell $ cat | cat | cat | ls
^C
Makefile	builtins	inc		libft		minishell	src		src_resaito
minishell $ echo $?
130
minishell $
```
シグナルはヒアドキュ中のcontrol D の終了ステータス以外はOK
control Dはif (line == NULL)の時の処理
96ではなく0にする必要がある
```
minishell $ cat << hoge
>
minishell $ echo $?
96
minishell $
```
以下は問題ないシグナル
```
minishell $ (control C)
minishell $ echo $?
1
minishell $ cat
^C
minishell $ echo $?
130
minishell $ cat
^\Quit: 3
minishell $ echo $?
131
minishell $ cat << hoge
>
minishell $ echo $?
1
minishell $
```