### PR TITLE
readline中にcntl + cを押したときの終了ステータスの修正

### DIFF
--- a/src/expand_utils.c
+++ b/src/expand_utils.c
@@ -49,7 +49,10 @@ int	check_question(t_parm *parm, t_envval *envval)
 	if (*(parm->tmp + 1) == '{' && *(parm->tmp + 2) == '?'
 		&& *(parm->tmp + 3) == '}')
 	{
-		tmp = ft_itoa(envval->status);
+		if (g_sig_status == 1)
+			tmp = ft_itoa(g_sig_status);
+		else
+			tmp = ft_itoa(envval->status);
 		parm->str = update_string_with_status(parm, tmp);
 		free(tmp);
 		if (!parm->str)
@@ -59,7 +62,10 @@ int	check_question(t_parm *parm, t_envval *envval)
 	}
 	else if (*(parm->tmp + 1) == '?')
 	{
-		tmp = ft_itoa(envval->status);
+		if (g_sig_status == 1)
+			tmp = ft_itoa(g_sig_status);
+		else
+			tmp = ft_itoa(envval->status);
 		parm->str = update_string_with_status(parm, tmp);
 		free(tmp);
 		if (!parm->str)


### PR DESCRIPTION
## やったこと
check_puestionの中でg_sig_statusが1の時にtmpに1を入れる処理を追加
```
tmp = ft_itoa(envval->status);
```
↓
```
if (g_sig_status == 1)
  tmp = ft_itoa(g_sig_status);
else
  tmp = ft_itoa(envval->status);
```
## 原因
check_statusがreadlineの前で実行されていたのでg_sig_statusが変更されていても0のままだった。
→echo $?の時に確認すればええやん！
→できた！

このテンション感でやったので間違ってるところもありそうなのでチェックお願いします。