### PR TITLE
exportコマンドで"/"など使用できるように修正

### DIFF
--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -152,6 +152,7 @@ void					envs_free(t_env *env);
 void					envs_str_free(t_env *env, char **str);
 void					env_free(t_env *env);
 t_envval				*make_envval(t_env *env);
+bool					is_name(char *str);
 
 // utils
 void					*ft_xmalloc(size_t size);

--- a/src_resaito/make_env.c
+++ b/src_resaito/make_env.c
@@ -53,6 +53,15 @@ t_env	*new_env(char *envp)
 		exit(1);
 	key_len = ft_strchr(envp, '=') - envp;
 	new->key = ft_strndup(envp, key_len);
+	if (!is_name(new->key))
+	{
+		ft_putstr_fd("minishell: export: `", STDERR_FILENO);
+		ft_putstr_fd(envp, STDERR_FILENO);
+		ft_putendl_fd("': not a valid identififer", STDERR_FILENO);
+		free(new->key);
+		free(new);
+		return(NULL);
+	}
 	value = ft_strchr(envp, '=') + 1;
 	new->value = ft_strdup(value);
 	new->next = NULL;


### PR DESCRIPTION
## やったこと
new_env()の方で特定の文字だった時にエラーを吐くようにした。
```
minishell $ export 1aa=hog/
minishell: export: `1aa=hog/': not a valid identififer
minishell $ echo $?
1
minishell $ export aa=/hoge
minishell $ echo $?
0
minishell $
```
valueでは色々な文字が対応することができるようになった。