### PR TITLE
環境変数を全てunsetした後にenvをするとクラッシュするのを修正

### DIFF
--- a/builtins/unset.c
+++ b/builtins/unset.c
@@ -69,10 +69,10 @@ static int	unset_single(char *name, t_envval *envval)
 	}
 	if (tmp->next)
 		remove_env_entry(&(envval->env), tmp_back, tmp);
+	else if (ft_strcmp(tmp->key, tmp_back->key) == 0)
+		envval->env = NULL;
 	else if (ft_strcmp(name, tmp->key) == 0)
 		tmp_back->next = NULL;
-	else
-		return (0);
 	env_free(tmp);
 	return (0);
 }
@@ -91,16 +91,27 @@ static int	unset_single(char *name, t_envval *envval)
 // int	main(int ac, char **av, char **envp)
 // {
 // 	t_node	*node;
+// 	t_node	*node2;
 // 	// t_env	*env;
 //     t_envval *envval;
 //     char    **array;
 //     int     size = 0;
-// 	char	*unset_arg[] = {"unset", "PATH", NULL};
+// 	char	*unset_arg[] = {"unset", "aaa", NULL};
+// 	char	*args[] = {"aaa=hoge", "hoge=fuga", NULL};
+// 	char	*unset_arg2[] = {"unset", "hoge", NULL};
 
 // 	node = make_node(N_COMMAND, unset_arg);
-// 	envval = make_envval(new_envs(envp)); //make_envval.c make_env.c
-// 	printf("%d\n",unset(node, envval));
+// 	node2 = make_node(N_COMMAND, unset_arg2);
+// 	envval = make_envval(new_envs(args)); //make_envval.c make_env.c
+// 	unset(node, envval);
+// 	unset(node2, envval);
+// 	// printf("%d\n",unset(node, envval));
 //     array = make_env_strs(envval->env); //make_env.c
+// 	if (array == NULL)
+// 	{
+// 		printf("array == NULL\n");
+// 		exit(1);
+// 	}
 //     envs_free(envval->env); // env_free.c
 //     free(envval);
 //     while (array[size] != NULL)
@@ -109,6 +120,7 @@ static int	unset_single(char *name, t_envval *envval)
 //         size++;
 //     }
 // 	free(node);
+// 	free(node2);
 //     str_array_free(array); //env_free.c ../src/free.c
 // 	// envs_str_free(env, array);
 // } // ../libft/libft.a

--- a/src/main.c
+++ b/src/main.c
@@ -28,7 +28,6 @@ void	minishell(char *line, t_envval *envval)
 		node_free(node);
 		return ;
 	}
-	print_node(node);
 	ft_execution(node, envval);
 	node_free(node);
 }

--- a/src_resaito/env_free.c
+++ b/src_resaito/env_free.c
@@ -14,6 +14,8 @@
 
 void	envs_free(t_env *env)
 {
+	if (!env)
+		return ;
 	if (env->next)
 		envs_free(env->next);
 	env_free(env);

--- a/src_resaito/make_env.c
+++ b/src_resaito/make_env.c
@@ -60,7 +60,7 @@ t_env	*new_env(char *envp)
 		ft_putendl_fd("': not a valid identififer", STDERR_FILENO);
 		free(new->key);
 		free(new);
-		return(NULL);
+		return (NULL);
 	}
 	value = ft_strchr(envp, '=') + 1;
 	new->value = ft_strdup(value);


### PR DESCRIPTION
## やったこと
環境変数が一つしかないときのif文の条件が甘かったのでちゃんと動くように変更
```
minishell $ unset first_env
~
minishell $ unset last_env
minishell $ env
minishell $
```
main.cでprint_nodeが生きたままだったので消しときます。