### PR TITLE
起動時に特定の環境変数がない時に初期化するように修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ NAME	= minishell
 
 SRCSDIR	= src/
 
-SRCS = main.c free.c check_line.c tokenize.c check_token.c parser.c redir_parser.c parser_utils.c lexer_parser_init.c expansion.c exp_init.c check_command.c expand_parameter.c expand_utils.c signal.c print.c
+SRCS = main.c free.c check_line.c check_env_init.c tokenize.c check_token.c parser.c redir_parser.c parser_utils.c lexer_parser_init.c expansion.c exp_init.c check_command.c expand_parameter.c expand_utils.c signal.c print.c
 
 RE_SRCSDIR	= src_resaito/
 

--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -6,7 +6,7 @@
 /*   By: resaito <resaito@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/18 21:17:45 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/12/18 18:32:25 by fwatanab         ###   ########.fr       */
+/*   Updated: 2023/12/28 16:09:17 by fwatanab         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -85,6 +85,9 @@ typedef struct s_envval
 	t_env				*env;
 	int					status;
 }						t_envval;
+
+//init env
+void					add_minimal_env_if_missing(t_env **env);
 
 //lexer parser
 t_token_list			*tokenize(const char *str);

--- a/src/check_env_init.c
+++ b/src/check_env_init.c
@@ -6,7 +6,7 @@
 /*   By: fwatanab <fwatanab@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/28 14:08:23 by fwatanab          #+#    #+#             */
-/*   Updated: 2023/12/28 16:09:04 by fwatanab         ###   ########.fr       */
+/*   Updated: 2023/12/28 16:18:26 by fwatanab         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -51,7 +51,8 @@ void	add_minimal_env_if_missing(t_env **env)
 	char	*tmp;
 
 	if (!find_env_var(*env, "PATH"))
-		envadd_back(env, new_env("PATH=/usr/local/bin:/usr/bin:/bin"));
+		envadd_back(env, new_env("PATH=/usr/local/bin:/System/Cryptexes/"
+				"App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/X11/bin"));
 	if (!find_env_var(*env, "PWD"))
 	{
 		if (getcwd(cwd, sizeof(cwd)))

--- a/src/check_env_init.c
+++ b/src/check_env_init.c
@@ -1,0 +1,73 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   check_env_init.c                                   :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: fwatanab <fwatanab@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/12/28 14:08:23 by fwatanab          #+#    #+#             */
+/*   Updated: 2023/12/28 16:09:04 by fwatanab         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../inc/minishell.h"
+
+static char	*create_home(char *pwd)
+{
+	char	*home;
+	size_t	i;
+	size_t	flag;
+
+	home = pwd;
+	i = 0;
+	flag = 0;
+	while (pwd[i])
+	{
+		if (pwd[i] == '/')
+			flag++;
+		if (flag == 3)
+			break ;
+		home[i] = pwd[i];
+		i++;
+	}
+	home[i] = '\0';
+	return (home);
+}
+
+static bool	find_env_var(t_env *env, const char *key)
+{
+	while (env)
+	{
+		if (strcmp(env->key, key) == 0)
+			return (true);
+		env = env->next;
+	}
+	return (false);
+}
+
+void	add_minimal_env_if_missing(t_env **env)
+{
+	char	cwd[PATH_MAX];
+	char	*tmp;
+
+	if (!find_env_var(*env, "PATH"))
+		envadd_back(env, new_env("PATH=/usr/local/bin:/usr/bin:/bin"));
+	if (!find_env_var(*env, "PWD"))
+	{
+		if (getcwd(cwd, sizeof(cwd)))
+		{
+			tmp = ft_strjoin("PWD=", cwd);
+			envadd_back(env, new_env(tmp));
+			free(tmp);
+		}
+	}
+	if (!find_env_var(*env, "HOME"))
+	{
+		tmp = create_home(cwd);
+		tmp = ft_strjoin("HOME=", tmp);
+		envadd_back(env, new_env(tmp));
+		free(tmp);
+	}
+	if (!find_env_var(*env, "SHELL"))
+		envadd_back(env, new_env("SHELL=/bin/zsh"));
+}

--- a/src_resaito/make_env.c
+++ b/src_resaito/make_env.c
@@ -6,7 +6,7 @@
 /*   By: resaito <resaito@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/30 15:12:57 by resaito           #+#    #+#             */
-/*   Updated: 2023/12/01 15:24:03 by resaito          ###   ########.fr       */
+/*   Updated: 2023/12/28 14:13:25 by fwatanab         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,6 +24,7 @@ t_env	*new_envs(char **envp)
 		envadd_back(&env, new_env(envp[size]));
 		size++;
 	}
+	add_minimal_env_if_missing(&env);
 	return (env);
 }
 


### PR DESCRIPTION
**挙動**
PATH, PWD, HOME, SHELLの４つは起動時にない場合設定するようにしました
↑は最低限必要かな？と思ったのにしました。(chatgptに聞きました)
正直この修正はクラッシュ回避にはならないような気がします(自己満説)

**注意**
環境変数なし(env -i)の場合getenvを使っても意味ないです(環境変数が存在しないため)

envの分野は詳しくないので間違ってたりすることがあるかもしれません
```
bash $ env -i ./minishell
minishell $ env
PATH=PATH=/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/X11/bin
PWD=/Users/sukakaedefutoshi/ft_git/minishell
HOME=/Users/sukakaedefutoshi
SHELL=/bin/zsh
minishell $
```